### PR TITLE
Windows compile fixes

### DIFF
--- a/Forms/Free2DDXFExportDlg.pas
+++ b/Forms/Free2DDXFExportDlg.pas
@@ -35,6 +35,9 @@ uses
     {$IFDEF Windows}
      Windows,
      shlobj,
+    {$ifdef LCL}
+    FileUtil,
+    {$endif}
     {$ELSE}
      LCLIntf, LCLType, LMessages,
      FileUtil,
@@ -217,4 +220,4 @@ begin
    FSetUnits;
 end;{TDXFExport2DDialog.ComboBox1Change}
 
-end.
+end.

--- a/Forms/FreeCrosscurvesDlg.pas
+++ b/Forms/FreeCrosscurvesDlg.pas
@@ -30,7 +30,7 @@ unit FreeCrosscurvesDlg;
 interface
 
 uses
-{$IFDEF Windows}
+{$IFNDEF LCL}
  Windows,
   TeEngine,
   Series,

--- a/Forms/FreeHydrodyn_ManeuvDlg.pas
+++ b/Forms/FreeHydrodyn_ManeuvDlg.pas
@@ -586,7 +586,7 @@ dat20 = 'Rudder Angle [degrees]'
 	  end;		  
 
 // Запускаем программу расчета
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec/ManeuvPP.EXE '),1);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys('Exec/ManeuvPP.EXE'), '', []);
@@ -827,4 +827,4 @@ begin
 end;{TFreeHydrodyn_Maneuv.File_IExportData}
 
 
-end.
+end.

--- a/Forms/FreeHydrodyn_RVRSDlg.pas
+++ b/Forms/FreeHydrodyn_RVRSDlg.pas
@@ -580,7 +580,7 @@ begin
 	  
 // Запускаем программу расчета
 
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\rvrsship.exe'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/RVRSSHIP.EXE'), '', []);

--- a/Forms/FreeHydrodyn_Task1Dlg.pas
+++ b/Forms/FreeHydrodyn_Task1Dlg.pas
@@ -412,7 +412,7 @@ begin
 	  end;		  
 
 // Запускаем программу расчета
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec/Ishercof.EXE'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/Ishercof.EXE'), '', []);

--- a/Forms/FreeHydrostaticsResultsDlg.pas
+++ b/Forms/FreeHydrostaticsResultsDlg.pas
@@ -34,7 +34,8 @@ interface
 uses
      {$ifdef Windows}
      Windows,
-     {$else}
+     {$endif}
+     {$ifdef LCL}
      LCLIntf, LCLType, LMessages, LResources,
      PrintersDlgs, Printer4Lazarus, FreePrinter,
      {$endif}
@@ -247,4 +248,4 @@ begin
 end;{TFreeHydrostaticsResultsDialog.SpeedButton1Click}
 
 end.
-
+

--- a/Forms/FreePropeller_Task1Dlg.pas
+++ b/Forms/FreePropeller_Task1Dlg.pas
@@ -618,7 +618,7 @@ begin
 		exit;
 	  end;		  
 
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\CalcProp.EXE'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/CALCPROP.EXE'), '', []);
@@ -806,7 +806,7 @@ begin
 // Переходим в директорию Freeshipa
       L:=SetCurrentDirUTF8(FOpenDirectory); { *Converted from SetCurrentDir* }
 // Запускаем программу расчета
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\dbfview.EXE'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/DBFview.EXE'), '', []);

--- a/Forms/FreePropeller_Task2Dlg.pas
+++ b/Forms/FreePropeller_Task2Dlg.pas
@@ -760,7 +760,7 @@ StartHere:
 		exit;
 	  end;		  
 
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\CalcProp.exe 2'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/CALCPROP.EXE'), '', []);

--- a/Forms/FreePropeller_Task3Dlg.pas
+++ b/Forms/FreePropeller_Task3Dlg.pas
@@ -633,7 +633,7 @@ begin
 		exit;
 	  end;		  
 
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\CalcProp.exe 3'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/CALCPROP.EXE'), '', []);

--- a/Forms/FreePropeller_Task4Dlg.pas
+++ b/Forms/FreePropeller_Task4Dlg.pas
@@ -481,7 +481,7 @@ dat16=EtaM
 	  end;		  
 
 // Запускаем программу расчета
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec/PropPred.EXE '),1);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/PropPred.EXE'), '', []);
@@ -682,7 +682,7 @@ begin
 // Переходим в директорию Freeshipa
 	  L:=SetCurrentDirUTF8(FFreeship.Preferences.TempDirectory); { *Converted from SetCurrentDir* }
 // Запускаем программу расчета
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FOpenDirectory+'Engines\dbfview'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/DBFview.EXE'), '', []);

--- a/Forms/FreePropeller_Task5Dlg.pas
+++ b/Forms/FreePropeller_Task5Dlg.pas
@@ -318,13 +318,13 @@ dat7=Velocity Vp
 
 // Запускаем программу расчета
 	 if Combobox.ItemIndex=0 then
-            {$ifdef Windows}
+            {$ifndef LCL}
             WinExec(PChar(FExecDirectory+'/Propol.EXE <IN.'),0)
             {$else}
             SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/PROPOL.EXE'), '', [])
             {$endif}
          else
-            {$ifdef Windows}
+            {$ifndef LCL}
             WinExec(PChar(FExecDirectory+'/FPPCALC.EXE'),0);
             {$else}
             SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/fppcalc.EXE'), '', []);
@@ -552,7 +552,7 @@ begin
 // Переходим в директорию Freeshipa
 	  L:=SetCurrentDirUTF8(FOpenDirectory); { *Converted from SetCurrentDir* }
 // Запускаем программу расчета
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FOpenDirectory+'Engines\dbfview'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys('Exec/DBFview.EXE'), '', []);

--- a/Forms/FreeResistance_FungLeibDlg.pas
+++ b/Forms/FreeResistance_FungLeibDlg.pas
@@ -682,7 +682,7 @@ begin
 		exit;
 	  end;		  
 
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\FungLeib.exe'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/fungleib.EXE'), '', []);
@@ -761,7 +761,7 @@ begin
 
 // Запускаем программу расчета
 
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\SeaMargn.EXE'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/SeaMargn.EXE'), '', []);

--- a/Forms/FreeResistance_HollenDlg.pas
+++ b/Forms/FreeResistance_HollenDlg.pas
@@ -700,7 +700,7 @@ DP_TA       0.430–0.840 0.655–1.050 0.495–0.860
 
     FExecDirectory:=FFreeship.Preferences.ExecDirectory;
 
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\hollenbh.exe'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/HOLLENBH.EXE'), '', []);
@@ -771,7 +771,7 @@ DP_TA       0.430–0.840 0.655–1.050 0.495–0.860
 
 // Запускаем программу расчета
 
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\SeaMargn.EXE'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/SeaMargn.EXE'), '', []);

--- a/Forms/FreeResistance_HoltrDlg.pas
+++ b/Forms/FreeResistance_HoltrDlg.pas
@@ -1923,7 +1923,7 @@ begin
 	  end;		  
 
 // Запускаем программу расчета
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\SeaMargn.EXE'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/SeaMargn.EXE'), '', []);

--- a/Forms/FreeResistance_MHDlg.pas
+++ b/Forms/FreeResistance_MHDlg.pas
@@ -1752,7 +1752,7 @@ begin
   FExecDirectory:=FFreeship.Preferences.ExecDirectory;
 
    File_ExportData(dat,dan);   	 // записываем файл данных в каталог Freeshipa
-   {$ifdef Windows}
+   {$ifndef LCL}
    WinExec(PChar(FileToFind+'Exec/hship.exe'),0); // запускаем расчет
    {$else}
    SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/hship.EXE'), '', []);

--- a/Forms/FreeResistance_OSTDlg.pas
+++ b/Forms/FreeResistance_OSTDlg.pas
@@ -1895,7 +1895,7 @@ begin
    PathFileOld:=FileToFind;   // задаем переменной каталог Freeshipa
    L:=SetCurrentDirUTF8(FFreeship.Preferences.TempDirectory); { *Converted from SetCurrentDir* } // переходим в каталог Freeshipa
    File_ExportData(dat,dan);   	 // записываем файл данных в каталог Freeshipa
-   {$ifdef Windows}
+   {$ifndef LCL}
    WinExec(PChar(FileToFind+'Exec/hship.exe'),0); // запускаем расчет
    {$else}
    SysUtils.ExecuteProcess(UTF8ToSys(FFreeship.Preferences.ExecDirectory+'/hship.EXE'), '', []);

--- a/Forms/FreeResistance_OortmerDlg.pas
+++ b/Forms/FreeResistance_OortmerDlg.pas
@@ -724,7 +724,7 @@ if (Lwl>0) and (Bwl>0) and (Dp>0) and (Np>0) and (Ta>0)then   begin
 	  end;		  
    if Combobox.ItemIndex=0 then begin // Oortmerssen метод
       Chart.Title.Text.Text:=Userstring(265)+' '+Userstring(1650);
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\OORTMERS.EXE'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/OORTMERS.EXE'), '', []);
@@ -733,7 +733,7 @@ if (Lwl>0) and (Bwl>0) and (Dp>0) and (Np>0) and (Ta>0)then   begin
                      end;
    if Combobox.ItemIndex=1 then begin  // Ridgeley-Nevitt метод
       Chart.Title.Text.Text:=Userstring(265)+' '+Userstring(1651);
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\RNTSP.exe'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/RNTSP.EXE'), '', []);
@@ -742,7 +742,7 @@ if (Lwl>0) and (Bwl>0) and (Dp>0) and (Np>0) and (Ta>0)then   begin
                      end;
    if Combobox.ItemIndex=2 then begin  // UBC метод
       Chart.Title.Text.Text:=Userstring(265)+' '+Userstring(1652);
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\UBCRT.exe'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/UBCRT.EXE'), '', []);
@@ -838,7 +838,7 @@ NewSearch:    FileToFind := FileSearchUTF8('TMP6.tsk',GetCurrentDir); { *Convert
 
 // Запускаем программу расчета
 
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\SeaMargn.EXE'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/SeaMargn.EXE'), '', []);

--- a/Forms/FreeResistance_PlaningDlg.pas
+++ b/Forms/FreeResistance_PlaningDlg.pas
@@ -1112,7 +1112,7 @@ begin
 	    MessageDlg(Userstring(1229),mtError,[mbOk],0); 
 		exit;
 	  end;		  
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\CLEMPOUP.EXE'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys('Exec/CLEMPOUP.EXE'), '', []);
@@ -1237,7 +1237,7 @@ NewSearch:    FileToFind := FileSearchUTF8('clempoup.dat',GetCurrentDir); { *Con
 	    MessageDlg(Userstring(1229),mtError,[mbOk],0); 
 		exit;
 	  end;		  
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\CLEMBLOU.EXE'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/CLEMBLOU.EXE'), '', []);
@@ -1377,7 +1377,7 @@ NewSearch1:    FileToFind := FileSearchUTF8('clemblou.dat',GetCurrentDir); { *Co
 	    MessageDlg(Userstring(1229),mtError,[mbOk],0); 
 		exit;
 	  end;		  
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\BUNKOV.EXE'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/BUNKOV.EXE'), '', []);
@@ -1500,7 +1500,7 @@ NewSearch2:    FileToFind := FileSearchUTF8('bunkdata.dat',GetCurrentDir); { *Co
 	    MessageDlg(Userstring(1229),mtError,[mbOk],0); 
 		exit;
 	  end;		  
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\COMPTON.EXE'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/COMPTON.EXE'), '', []);
@@ -1621,7 +1621,7 @@ NewSearch3:    FileToFind := FileSearchUTF8('cmptdata.dat',GetCurrentDir); { *Co
 	    MessageDlg(Userstring(1229),mtError,[mbOk],0); 
 		exit;
 	  end;		  
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\Wolfson.EXE'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/WOLFSON.EXE'), '', []);
@@ -1748,7 +1748,7 @@ NewSearch4:    FileToFind := FileSearchUTF8('wolfdata.dat',GetCurrentDir); { *Co
 	    MessageDlg(Userstring(1229),mtError,[mbOk],0); 
 		exit;
 	  end;		  
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec\Radojcic.EXE'),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/RADOJCIC.EXE'), '', []);

--- a/Forms/FreeResistance_RBHSDlg.pas
+++ b/Forms/FreeResistance_RBHSDlg.pas
@@ -1672,7 +1672,7 @@ begin
 
    File_ExportData(dat,dan);   	 // записываем файл данных в каталог Freeshipa
 
-   {$ifdef Windows}
+   {$ifndef LCL}
    WinExec(PChar(FileToFind+'Exec/hship.exe'),0); // запускаем расчет
    {$else}
    SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/hship.EXE'), '', []);

--- a/Forms/FreeSplashWndw.pas
+++ b/Forms/FreeSplashWndw.pas
@@ -33,9 +33,10 @@ unit FreeSplashWndw;
 interface
 
 uses
-{$IFnDEF FPC}
-  ShellAPI, jpeg, Windows,
-{$ELSE}
+{$IFDEF Windows}
+  ShellAPI, {$ifndef LCL} jpeg, {$endif} Windows,
+{$ENDIF}
+{$IFDEF LCL}
   LCLIntf, LCLType, LMessages,
 {$ENDIF}
   Messages,
@@ -109,7 +110,7 @@ type
      dwFlags : DWORD      // action
      ): BOOL; stdcall;
 
-{$IFDEF WINDOWS}
+{$IFNDEF LCL}
 procedure SetTransparentForm(form: TForm; AValue : byte = 0);
 var
  Info: TOSVersionInfo;
@@ -212,4 +213,4 @@ begin
    // End Skip translation
 end;{TFreeSplashWindow.Label4Click}
 
-end.
+end.

--- a/Forms/Main.pas
+++ b/Forms/Main.pas
@@ -37,7 +37,7 @@ unit Main;
 interface
 
 uses
-{$IFDEF WINDOWS}
+{$IFNDEF LCL}
   jpeg, ShellAPI, Windows,
 {$ELSE}
   LCLIntf, LCLType, LMessages,
@@ -699,7 +699,7 @@ begin
          HullformWindow.Left := I * 40;
          HullformWindow.Top := I * 40;
       end;
-      {$ifdef Windows}
+      {$ifndef LCL}
         TileMode := tbHorizontal;
       {$endif}
       Tile;
@@ -1071,17 +1071,17 @@ end;{TMainForm.Cascade}
 
 procedure TMainForm.TileWindowExecute(Sender: TObject);
 begin
-  {$ifdef Windows}
+  {$ifndef LCL}{$ifndef CLX}
   TileMode := tbHorizontal;
-  {$endif}
+  {$endif}{$endif}
   Tile;
 end;{TMainForm.TileWindowExecute}
 
 procedure TMainForm.CascadeWindowExecute(Sender: TObject);
 begin
-  {$ifdef Windows}
+  {$ifndef LCL}{$ifndef CLX}
   TileMode := tbHorizontal;
-  {$endif}
+  {$endif}{$endif}
   Cascade;
 end;{TMainForm.CascadeWindowExecute}
 

--- a/Packages/FreePackage.lpk
+++ b/Packages/FreePackage.lpk
@@ -6,9 +6,9 @@
     <CompilerOptions>
       <Version Value="11"/>
       <SearchPaths>
-        <IncludeFiles Value="$(ProjPath)/;$(ProjPath)/Forms/;$(ProjPath)/Units/"/>
-        <Libraries Value="$(ProjPath)/Units/"/>
-        <OtherUnitFiles Value="$(ProjPath)/Forms/;$(ProjPath)/Units/"/>
+        <IncludeFiles Value="$(ProjPath);$(ProjPath)/Forms;$(ProjPath)/Units;../Forms;../Units;.."/>
+        <Libraries Value="$(ProjPath)/Units"/>
+        <OtherUnitFiles Value="$(ProjPath)/Forms;$(ProjPath)/Units;../Forms;../Units"/>
         <UnitOutputDirectory Value="lib/$(TargetCPU)-$(TargetOS)"/>
         <ObjectPath Value="../Units"/>
       </SearchPaths>

--- a/Units/FreeGeometry.pas
+++ b/Units/FreeGeometry.pas
@@ -3442,7 +3442,7 @@ begin
    Screen.Cursors[crSetOrigin]:=LoadCursor(hInstance,'SETORIGIN');
    Screen.Cursors[crSetScale]:=LoadCursor(hInstance,'SETSCALE');
    Screen.Cursors[crTranspCol]:=LoadCursor(hInstance,'TRANSPARENTCOLOR');
-   writeln('TFreeViewport.Create: done');
+   logger.debug('TFreeViewport.Create: done');
 end;{TFreeViewport.Create}
 
 destructor TFreeViewport.Destroy;

--- a/Units/FreeLogger.pas
+++ b/Units/FreeLogger.pas
@@ -5,7 +5,8 @@ unit FreeLogger;
 interface
 
 uses
-  Classes, SysUtils;
+  Classes, SysUtils
+  {$ifdef LCL}, LazLogger{$endif};
 
 const
   LOG_NONE = 0;
@@ -39,25 +40,42 @@ end;
 procedure TLogger.Info(S:String);
 begin
   if FLogLevel >= LOG_INFO then
-    writeln(S);
+  begin
+    {$ifdef LCL}
+    debugln(S);
+    {$endif}
+  end;
 end;
+
 
 procedure TLogger.Warning(S:String);
 begin
   if FLogLevel >= LOG_WARNING then
-    writeln(S);
+  begin
+    {$ifdef LCL}
+    debugln(S);
+    {$endif}
+  end;
 end;
 
 procedure TLogger.Error(S:String);
 begin
   if FLogLevel >= LOG_ERROR then
-    writeln(S);
+  begin
+    {$ifdef LCL}
+    debugln(S);
+    {$endif}
+  end;
 end;
 
 procedure TLogger.Debug(S:String);
 begin
   if FLogLevel >= LOG_DEBUG then
-    writeln(S);
+  begin
+    {$ifdef LCL}
+    debugln(S);
+    {$endif}
+  end;
 end;
 
 procedure TLogger.SetLogLevel(L:integer);

--- a/Units/FreeNumInput.pas
+++ b/Units/FreeNumInput.pas
@@ -9,9 +9,12 @@ interface
 uses
      {$ifdef Windows}
      Windows,
+     {$ifndef LCL}
      WinTypes,
      WinProcs,
-     {$else}
+     {$endif}
+     {$endif}
+     {$ifdef LCL}
      LCLIntf, LCLType, LMessages, LResources,
      {$endif}
      SysUtils,

--- a/Units/FreeShipUnit.pas
+++ b/Units/FreeShipUnit.pas
@@ -35,12 +35,11 @@ unit FreeShipUnit;
 interface
 
 uses SysUtils,// this declaration must be at the start, before the FreeGeometry unit
-     {$ifndef LCL}
+     {$ifdef windows}
       Windows,
-     Graphics,
-     Controls,
-     JPeg,
-     {$else}
+     {$ifndef LCL} JPeg,{$endif}
+     {$endif}
+     {$ifdef LCL}
       Interfaces, LCLIntf, LCLType, LCLProc,
       LMessages,
       GraphType, GraphMath, Graphics, Controls,

--- a/Units/FreeShipUnit.pas
+++ b/Units/FreeShipUnit.pas
@@ -35,7 +35,7 @@ unit FreeShipUnit;
 interface
 
 uses SysUtils,// this declaration must be at the start, before the FreeGeometry unit
-     {$ifdef Windows}
+     {$ifndef LCL}
       Windows,
      Graphics,
      Controls,
@@ -7726,7 +7726,7 @@ var
   	  exit;
 	  end;	
       ShowMessage('        HydroNShIp_AddedMass v1.03'#13#10#13#10+'                      Calculating...'#13#10#13#10+'Copyright (c) 2008-2009, Timoshenko V.F.');
-      {$ifdef Windows}
+      {$ifndef LCL}
       WinExec(PChar(FInitDirectory+'Exec/Add_Mass.EXE '),0);
       {$else}
       SysUtils.ExecuteProcess(UTF8ToSys(FExecDirectory+'/Add_Mass.EXE'), '', []);

--- a/Units/VRMLUnit.pas
+++ b/Units/VRMLUnit.pas
@@ -10,7 +10,8 @@ interface
 uses
     {$IFDEF Windows}
     Windows,
-    {$ELSE}
+    {$ENDIF}
+    {$IFDEF LCL}
     FileUtil,
     {$ENDIF}
      Classes,
@@ -771,4 +772,4 @@ begin
    end;
 end;{TVRMLList.LoadFromFile}
 
-end.
+end.


### PR DESCRIPTION
Hi Mark,

I rewrote some {$ifdef Windows} to {$ifndef LCL} to make it compile on Lazarus for Windows. But maybe the Windows-Delphi-specific stuff should be discarded anyway.
I have no Delphi and my Windows is an old XP running under Virtualbox, so I can not test thoroughly.

Windows has no console, writeln() to stdout gives an error. So I made FreeLogger use debugln() on Lazarus.

Please excuse that this is just trivial work, but I am new to Lazarus. So use with care.

Best wishes from Hamburg, Germany,
Sönke

PS:
I promoted your work on http://wiki.freepascal.org/Projects_using_Lazarus#FREE.21ship_Plus_in_Lazarus