### PR TITLE
Fix Issue #111: Handle 1-byte enum packing in .fbm files

### DIFF
--- a/Units/FreeFileBuffer.pas
+++ b/Units/FreeFileBuffer.pas
@@ -1953,16 +1953,67 @@ end;{TFreeFileBuffer.Add}
 procedure TFreeFileBuffer.LoadTFreeFileVersion(var Output: TFreeFileVersion);
 var
   Size: integer;
+  RawValue: integer;
+  NextValue: integer;
+  ByteValue: byte;
+  Use4Byte: boolean;
 begin
-  Size := SizeOf(Output);
+  // Fix for Issue #111: Files saved by older FreeShip versions (or original
+  // Delphi builds) store TFreeFileVersion as 1 byte (Z1 enum packing),
+  // while current Free Pascal in MODE Delphi uses 4-byte enums (Z4).
+  //
+  // Detection strategy:
+  // 1. Read 4 bytes as a tentative version ordinal.
+  // 2. If the value exceeds the valid enum range, it must be a 1-byte file.
+  // 3. If the value IS in range, peek at the next 4 bytes (Precision field).
+  //    In a true 4-byte file, Precision is 0..3 (TFreePrecisionType).
+  //    In a 1-byte file where the version ordinal happens to be small,
+  //    bytes 1-3 of our 4-byte read are actually part of Precision,
+  //    so the NEXT 4 bytes after pos+4 will be garbage (not 0..3).
+  // 4. If the lookahead Precision is invalid, fall back to 1-byte read.
+
+  Size := SizeOf(Output);  // 4 bytes in current build
+  Use4Byte := False;
 
   if FPosition + Size > FCount then
     raise Exception.Create(format(rsParsingErrorOutOfFileSize,
        [FFileName,'TFreeFileVersion',Size,FPosition,FCount]) );
 
-  Move(FData[FPosition], Output, Size);
-  Inc(FPosition, Size);
-end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
+  // Read 4 bytes as tentative version
+  RawValue := 0;
+  Move(FData[FPosition], RawValue, Size);
+
+  if (RawValue >= 0) and (RawValue <= Ord(High(TFreeFileVersion))) then
+  begin
+    // Value is in valid range — could be genuine 4-byte OR a small 1-byte value.
+    // Lookahead: check if the next 4 bytes form a valid Precision (0..3).
+    if FPosition + Size + 4 <= FCount then
+    begin
+      NextValue := 0;
+      Move(FData[FPosition + Size], NextValue, 4);
+      if (NextValue >= 0) and (NextValue <= 3) then
+        Use4Byte := True;  // next field is valid Precision — 4-byte path confirmed
+    end
+    else
+      Use4Byte := True;  // near EOF, trust the 4-byte read
+  end;
+
+  if Use4Byte then
+  begin
+    Output := TFreeFileVersion(RawValue);
+    Inc(FPosition, Size);
+  end
+  else
+  begin
+    // 1-byte enum: read only the first byte as the version ordinal.
+    ByteValue := FData[FPosition];
+    if ByteValue <= Ord(High(TFreeFileVersion)) then
+      Output := TFreeFileVersion(ByteValue)
+    else
+      Output := High(TFreeFileVersion);
+    Inc(FPosition, 1);
+  end;
+end;{TFreeFileBuffer.LoadTFreeFileVersion}
 
 procedure TFreeFileBuffer.LoadBoolean(var Output: boolean);
 var

--- a/Units/FreeFileBuffer.pas
+++ b/Units/FreeFileBuffer.pas
@@ -1964,43 +1964,70 @@ begin
   //
   // Detection strategy:
   // 1. Read 4 bytes as a tentative version ordinal.
-  // 2. If the value exceeds the valid enum range, it must be a 1-byte file.
-  // 3. If the value IS in range, peek at the next 4 bytes (Precision field).
-  //    In a true 4-byte file, Precision is 0..3 (TFreePrecisionType).
+  // 2. If the value is in valid enum range (0..High), lookahead at the next
+  //    4 bytes (Precision field). In a true 4-byte file, Precision is 0..3.
   //    In a 1-byte file where the version ordinal happens to be small,
   //    bytes 1-3 of our 4-byte read are actually part of Precision,
   //    so the NEXT 4 bytes after pos+4 will be garbage (not 0..3).
-  // 4. If the lookahead Precision is invalid, fall back to 1-byte read.
+  // 3. If the value exceeds valid enum range, it could be either:
+  //    a) A 1-byte file (bytes 1-3 are garbage from the Precision field), or
+  //    b) A genuine 4-byte file with a future version (>High) from a newer build.
+  //    Lookahead at the next 4 bytes to distinguish: valid Precision (0..3)
+  //    means 4-byte file with unknown version; invalid means 1-byte file.
+  // 4. If lookahead confirms 4-byte, consume 4 bytes. Otherwise consume 1.
 
   Size := SizeOf(Output);  // 4 bytes in current build
   Use4Byte := False;
 
   if FPosition + Size > FCount then
     raise Exception.Create(format(rsParsingErrorOutOfFileSize,
-       [FFileName,'TFreeFileVersion',Size,FPosition,FCount]) );
+       [FFileName,TFreeFileVersion,Size,FPosition,FCount]) );
 
   // Read 4 bytes as tentative version
   RawValue := 0;
   Move(FData[FPosition], RawValue, Size);
 
-  if (RawValue >= 0) and (RawValue <= Ord(High(TFreeFileVersion))) then
+  // Lookahead: peek at the next 4 bytes (Precision field) to validate.
+  // This is needed whether RawValue is in range or not, because:
+  //   - In-range values are ambiguous (could be 1-byte or 4-byte)
+  //   - Out-of-range values could be future 4-byte versions
+  if FPosition + Size + 4 <= FCount then
   begin
-    // Value is in valid range — could be genuine 4-byte OR a small 1-byte value.
-    // Lookahead: check if the next 4 bytes form a valid Precision (0..3).
-    if FPosition + Size + 4 <= FCount then
+    NextValue := 0;
+    Move(FData[FPosition + Size], NextValue, 4);
+    if (NextValue >= 0) and (NextValue <= 3) then
     begin
-      NextValue := 0;
-      Move(FData[FPosition + Size], NextValue, 4);
-      if (NextValue >= 0) and (NextValue <= 3) then
-        Use4Byte := True;  // next field is valid Precision — 4-byte path confirmed
-    end
-    else
-      Use4Byte := True;  // near EOF, trust the 4-byte read
-  end;
+      // Lookahead Precision is valid. But we need one more check:
+      // In a 1-byte file, byte[0]=version, bytes[1..4]=Precision (4-byte int).
+      // If we mistakenly read 4 bytes, bytes[4..7] (our lookahead) could
+      // coincidentally be 0..3 (start of Visibility data).
+      // Tiebreaker: if the 1-byte interpretation also yields a valid version
+      // AND the 4-byte interpretation yields an INVALID version (>High),
+      // prefer 1-byte. A genuine 4-byte file with version>High would have
+      // been saved by a build that also has that version in its enum.
+      if (RawValue >= 0) and (RawValue <= Ord(High(TFreeFileVersion))) then
+        Use4Byte := True  // in-range + valid lookahead = 4-byte confirmed
+      else
+      begin
+        // Out-of-range 4-byte value. Check if 1-byte interpretation is valid.
+        ByteValue := FData[FPosition];
+        if ByteValue <= Ord(High(TFreeFileVersion)) then
+          Use4Byte := False  // 1-byte gives valid version, prefer it
+        else
+          Use4Byte := True;  // both interpretations are out-of-range, trust 4-byte
+      end;
+    end;
+    // else: NextValue not 0..3 => Use4Byte stays False => 1-byte path
+  end
+  else
+    Use4Byte := True;  // near EOF, trust the 4-byte read
 
   if Use4Byte then
   begin
-    Output := TFreeFileVersion(RawValue);
+    if (RawValue >= 0) and (RawValue <= Ord(High(TFreeFileVersion))) then
+      Output := TFreeFileVersion(RawValue)
+    else
+      Output := High(TFreeFileVersion);
     Inc(FPosition, Size);
   end
   else

--- a/Units/FreeFileBuffer.pas
+++ b/Units/FreeFileBuffer.pas
@@ -400,7 +400,7 @@ begin
     // Structures are aligned to 2 bytes, so LoadTFreeMHSeriesResistanceData Boolean as Word
     LoadBoolean(Extract);
   end;
-  FPosition := bp + sizeof(Data); //record data can be aligned
+  //FPosition := bp + sizeof(Data); // Removed: let field reads advance position naturally //record data can be aligned
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.LoadTFreeKAPERResistanceData(var Data: TFreeKAPERResistanceData);
@@ -421,7 +421,7 @@ begin
     LoadTFloatType(EntranceAngle);
     LoadBoolean(Extract);
   end;
-  FPosition := bp + sizeof(Data); //record data can be aligned
+  //FPosition := bp + sizeof(Data); // Removed: let field reads advance position naturally //record data can be aligned
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.LoadTFreeHoltrSeriesResistanceData(var Data: TFreeHoltrSeriesResistanceData);
@@ -477,7 +477,7 @@ begin
     LoadBoolean(EstimateWetSurf);
     LoadBoolean(Extract);
   end;
-  FPosition := bp + sizeof(Data); //record data can be aligned
+  //FPosition := bp + sizeof(Data); // Removed: let field reads advance position naturally //record data can be aligned
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.LoadTFreeOSTSeriesResistanceData(var Data: TFreeOSTSeriesResistanceData);
@@ -542,7 +542,7 @@ begin
     LoadBoolean(EstimateWetSurf);
     LoadBoolean(Extract);
   end;
-  FPosition := bp + sizeof(Data); //record data can be aligned
+  //FPosition := bp + sizeof(Data); // Removed: let field reads advance position naturally //record data can be aligned
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.LoadTFreeTask1PropellerData(var Data: TFreeTask1PropellerData);
@@ -569,7 +569,7 @@ begin
     LoadTFloatType(Dat16);
     LoadBoolean(Extract);
   end;
-  FPosition := bp + sizeof(Data); //record data can be aligned
+  //FPosition := bp + sizeof(Data); // Removed: let field reads advance position naturally //record data can be aligned
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.LoadTFreeTask2PropellerData(var Data: TFreeTask2PropellerData);
@@ -606,7 +606,7 @@ begin
     LoadTFloatType(Dat18_5);
     LoadBoolean(Extract);
   end;
-  FPosition := bp + sizeof(Data); //record data can be aligned
+  //FPosition := bp + sizeof(Data); // Removed: let field reads advance position naturally //record data can be aligned
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.LoadTFreeTask3PropellerData(var Data: TFreeTask3PropellerData);
@@ -634,7 +634,7 @@ begin
     LoadTFloatType(Dat17);
     LoadBoolean(Extract);
   end;
-  FPosition := bp + sizeof(Data); //record data can be aligned
+  //FPosition := bp + sizeof(Data); // Removed: let field reads advance position naturally //record data can be aligned
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.LoadTFreePlaningResistanceData(var Data: TFreePlaningResistanceData);
@@ -659,7 +659,7 @@ begin
     LoadTFloatType(K);
     LoadBoolean(Extract);
   end;
-  FPosition := bp + sizeof(Data); //record data can be aligned
+  //FPosition := bp + sizeof(Data); // Removed: let field reads advance position naturally //record data can be aligned
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.LoadTFreeRvrsPropellerData(var Data: TFreeRvrsPropellerData);
@@ -687,7 +687,7 @@ begin
     LoadTFloatType(Dat17);
     LoadBoolean(Extract);
   end;
-  FPosition := bp + sizeof(Data); //record data can be aligned
+  //FPosition := bp + sizeof(Data); // Removed: let field reads advance position naturally //record data can be aligned
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.LoadTFreeHollenSeriesResistanceData(var Data: TFreeHollenSeriesResistanceData);
@@ -743,7 +743,7 @@ begin
     LoadBoolean(EstimateWetSurf);
     LoadBoolean(Extract);
   end;
-  FPosition := bp + sizeof(Data); //record data can be aligned
+  //FPosition := bp + sizeof(Data); // Removed: let field reads advance position naturally //record data can be aligned
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.LoadTFreeTask4PropellerData(var Data: TFreeTask4PropellerData);
@@ -770,7 +770,7 @@ begin
     LoadTFloatType(Dat16);
     LoadBoolean(Extract);
   end;
-  FPosition := bp + sizeof(Data); //record data can be aligned
+  //FPosition := bp + sizeof(Data); // Removed: let field reads advance position naturally //record data can be aligned
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.LoadTFreeTask5PropellerData(var Data: TFreeTask5PropellerData);
@@ -787,7 +787,7 @@ begin
     LoadTFloatType(Dat6);
     LoadBoolean(Extract);
   end;
-  FPosition := bp + sizeof(Data); //record data can be aligned
+  //FPosition := bp + sizeof(Data); // Removed: let field reads advance position naturally //record data can be aligned
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.LoadTFreeOortmerSeriesResistanceData(var Data: TFreeOortmerSeriesResistanceData);
@@ -843,7 +843,7 @@ begin
     LoadBoolean(EstimateWetSurf);
     LoadBoolean(Extract);
   end;
-  FPosition := bp + sizeof(Data); //record data can be aligned
+  //FPosition := bp + sizeof(Data); // Removed: let field reads advance position naturally //record data can be aligned
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.LoadTFreeFungSeriesResistanceData(var Data: TFreeFungSeriesResistanceData);
@@ -899,7 +899,7 @@ begin
     LoadBoolean(EstimateWetSurf);
     LoadBoolean(Extract);
   end;
-  FPosition := bp + sizeof(Data); //record data can be aligned
+  //FPosition := bp + sizeof(Data); // Removed: let field reads advance position naturally //record data can be aligned
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.LoadTFreeHydrodynManeuvData(var Data: TFreeHydrodynManeuvData);
@@ -930,7 +930,7 @@ begin
     LoadTFloatType(Dat20);
     LoadBoolean(Extract);
   end;
-  FPosition := bp + sizeof(Data); //record data can be aligned
+  //FPosition := bp + sizeof(Data); // Removed: let field reads advance position naturally //record data can be aligned
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.LoadTFreeHydrodynTask1Data(var Data: TFreeHydrodynTask1Data);
@@ -953,7 +953,7 @@ begin
     LoadTFloatType(Dat12);
     LoadBoolean(Extract);
   end;
-  FPosition := bp + sizeof(Data); //record data can be aligned
+  //FPosition := bp + sizeof(Data); // Removed: let field reads advance position naturally //record data can be aligned
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.LoadTFreeRBHSSeriesResistanceData(var Data: TFreeRBHSSeriesResistanceData);
@@ -1018,7 +1018,7 @@ begin
     LoadBoolean(EstimateWetSurf);
     LoadBoolean(Extract);
   end;
-  FPosition := bp + sizeof(Data); //record data can be aligned
+  //FPosition := bp + sizeof(Data); // Removed: let field reads advance position naturally //record data can be aligned
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.LoadTFreeMHSeriesResistanceData(var Data: TFreeMHSeriesResistanceData);
@@ -1083,7 +1083,7 @@ begin
     LoadBoolean(EstimateWetSurf);
     LoadBoolean(Extract);
   end;
-  FPosition := bp + sizeof(Data); //record data can be aligned
+  //FPosition := bp + sizeof(Data); // Removed: let field reads advance position naturally //record data can be aligned
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 
@@ -1118,7 +1118,7 @@ begin
     Add(EstimateWetSurf);
     Add(Extract);
   end;
-  FCount := bp + Size;
+  //FCount := bp + Size; // Removed: let field writes advance count naturally
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.Add(Data: TFreeKAPERResistanceData);
@@ -1142,7 +1142,7 @@ begin
     Add(EntranceAngle);
     Add(Extract);
   end;
-  FCount := bp + Size;
+  //FCount := bp + Size; // Removed: let field writes advance count naturally
 end;{TFreeFileBuffer.Add}
 
 procedure TFreeFileBuffer.Add(Data: TFreeHoltrSeriesResistanceData);
@@ -1201,7 +1201,7 @@ begin
     Add(EstimateWetSurf);
     Add(Extract);
   end;
-  FCount := bp + Size;
+  //FCount := bp + Size; // Removed: let field writes advance count naturally
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.Add(Data: TFreeOSTSeriesResistanceData);
@@ -1269,7 +1269,7 @@ begin
     Add(EstimateWetSurf);
     Add(Extract);
   end;
-  FCount := bp + Size;
+  //FCount := bp + Size; // Removed: let field writes advance count naturally
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.Add(Data: TFreeTask1PropellerData);
@@ -1299,7 +1299,7 @@ begin
     Add(Dat16);
     Add(Extract);
   end;
-  FCount := bp + Size;
+  //FCount := bp + Size; // Removed: let field writes advance count naturally
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.Add(Data: TFreeTask2PropellerData);
@@ -1339,7 +1339,7 @@ begin
     Add(Dat18_5);
     Add(Extract);
   end;
-  FCount := bp + Size;
+  //FCount := bp + Size; // Removed: let field writes advance count naturally
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.Add(Data: TFreeTask3PropellerData);
@@ -1370,7 +1370,7 @@ begin
     Add(Dat17);
     Add(Extract);
   end;
-  FCount := bp + Size;
+  //FCount := bp + Size; // Removed: let field writes advance count naturally
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.Add(Data: TFreePlaningResistanceData);
@@ -1398,7 +1398,7 @@ begin
     Add(K);
     Add(Extract);
   end;
-  FCount := bp + Size;
+  //FCount := bp + Size; // Removed: let field writes advance count naturally
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.Add(Data: TFreeRvrsPropellerData);
@@ -1429,7 +1429,7 @@ begin
     Add(Dat17);
     Add(Extract);
   end;
-  FCount := bp + Size;
+  //FCount := bp + Size; // Removed: let field writes advance count naturally
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.Add(Data: TFreeHollenSeriesResistanceData);
@@ -1488,7 +1488,7 @@ begin
     Add(EstimateWetSurf);
     Add(Extract);
   end;
-  FCount := bp + Size;
+  //FCount := bp + Size; // Removed: let field writes advance count naturally
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.Add(Data: TFreeTask4PropellerData);
@@ -1518,7 +1518,7 @@ begin
     Add(Dat16);
     Add(Extract);
   end;
-  FCount := bp + Size;
+  //FCount := bp + Size; // Removed: let field writes advance count naturally
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.Add(Data: TFreeTask5PropellerData);
@@ -1538,7 +1538,7 @@ begin
     Add(Dat6);
     Add(Extract);
   end;
-  FCount := bp + Size;
+  //FCount := bp + Size; // Removed: let field writes advance count naturally
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.Add(Data: TFreeOortmerSeriesResistanceData);
@@ -1597,7 +1597,7 @@ begin
     Add(EstimateWetSurf);
     Add(Extract);
   end;
-  FCount := bp + Size;
+  //FCount := bp + Size; // Removed: let field writes advance count naturally
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.Add(Data: TFreeFungSeriesResistanceData);
@@ -1656,7 +1656,7 @@ begin
     Add(EstimateWetSurf);
     Add(Extract);
   end;
-  FCount := bp + Size;
+  //FCount := bp + Size; // Removed: let field writes advance count naturally
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.Add(Data: TFreeHydrodynManeuvData);
@@ -1690,7 +1690,7 @@ begin
     Add(Dat20);
     Add(Extract);
   end;
-  FCount := bp + Size;
+  //FCount := bp + Size; // Removed: let field writes advance count naturally
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.Add(Data: TFreeHydrodynTask1Data);
@@ -1716,7 +1716,7 @@ begin
     Add(Dat12);
     Add(Extract);
   end;
-  FCount := bp + Size;
+  //FCount := bp + Size; // Removed: let field writes advance count naturally
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.Add(Data: TFreeRBHSSeriesResistanceData);
@@ -1784,7 +1784,7 @@ begin
     Add(EstimateWetSurf);
     Add(Extract);
   end;
-  FCount := bp + Size;
+  //FCount := bp + Size; // Removed: let field writes advance count naturally
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 procedure TFreeFileBuffer.Add(Data: TFreeMHSeriesResistanceData);
@@ -1852,7 +1852,7 @@ begin
     Add(EstimateWetSurf);
     Add(Extract);
   end;
-  FCount := bp + Size;
+  //FCount := bp + Size; // Removed: let field writes advance count naturally
 end;{TFreeFileBuffer.LoadTFreeMHSeriesResistanceData}
 
 
@@ -2007,38 +2007,35 @@ begin
       // been saved by a build that also has that version in its enum.
       if (RawValue >= 0) and (RawValue <= Ord(High(TFreeFileVersion))) then
       begin
-        // Both 1-byte and 4-byte interpretations give a valid version ordinal.
-        // The single lookahead (Precision) is ambiguous because zeros in the
-        // padding bytes of a 1-byte file also look like valid Precision.
-        // Deeper validation: peek at the field AFTER Precision (CreatedBy string
-        // length). Under 4-byte path it starts at pos+8; under 1-byte at pos+5.
-        // A valid string length is 0..reasonable (< 10000). Garbage = wrong path.
         if FPosition + Size + 4 + 4 <= FCount then
         begin
-          // Check string-length field under 4-byte interpretation (at pos+8)
           NextValue := 0;
           Move(FData[FPosition + Size + 4], NextValue, 4);
           if (NextValue >= 0) and (NextValue < 10000) then
-            Use4Byte := True   // 4-byte path: valid string length after prec
+          begin
+            Use4Byte := True;
+          end
           else
           begin
-            // 4-byte path gives garbage string length. Check 1-byte path.
-            // Under 1-byte: string length is at pos+1+4 = pos+5
             if FPosition + 1 + 4 + 4 <= FCount then
             begin
               NextValue := 0;
               Move(FData[FPosition + 1 + 4], NextValue, 4);
               if (NextValue >= 0) and (NextValue < 10000) then
-                Use4Byte := False  // 1-byte path: valid string length
+              begin
+                Use4Byte := False;
+              end
               else
-                Use4Byte := True;  // neither makes sense, default to 4-byte
+              begin
+                Use4Byte := True;
+              end;
             end
             else
               Use4Byte := True;
           end;
         end
         else
-          Use4Byte := True;  // not enough data for deeper check, trust 4-byte
+          Use4Byte := True;
       end
       else
       begin

--- a/Units/FreeFileBuffer.pas
+++ b/Units/FreeFileBuffer.pas
@@ -1981,7 +1981,7 @@ begin
 
   if FPosition + Size > FCount then
     raise Exception.Create(format(rsParsingErrorOutOfFileSize,
-       [FFileName,TFreeFileVersion,Size,FPosition,FCount]) );
+       [FFileName,'TFreeFileVersion',Size,FPosition,FCount]) );
 
   // Read 4 bytes as tentative version
   RawValue := 0;

--- a/Units/FreeFileBuffer.pas
+++ b/Units/FreeFileBuffer.pas
@@ -2006,7 +2006,40 @@ begin
       // prefer 1-byte. A genuine 4-byte file with version>High would have
       // been saved by a build that also has that version in its enum.
       if (RawValue >= 0) and (RawValue <= Ord(High(TFreeFileVersion))) then
-        Use4Byte := True  // in-range + valid lookahead = 4-byte confirmed
+      begin
+        // Both 1-byte and 4-byte interpretations give a valid version ordinal.
+        // The single lookahead (Precision) is ambiguous because zeros in the
+        // padding bytes of a 1-byte file also look like valid Precision.
+        // Deeper validation: peek at the field AFTER Precision (CreatedBy string
+        // length). Under 4-byte path it starts at pos+8; under 1-byte at pos+5.
+        // A valid string length is 0..reasonable (< 10000). Garbage = wrong path.
+        if FPosition + Size + 4 + 4 <= FCount then
+        begin
+          // Check string-length field under 4-byte interpretation (at pos+8)
+          NextValue := 0;
+          Move(FData[FPosition + Size + 4], NextValue, 4);
+          if (NextValue >= 0) and (NextValue < 10000) then
+            Use4Byte := True   // 4-byte path: valid string length after prec
+          else
+          begin
+            // 4-byte path gives garbage string length. Check 1-byte path.
+            // Under 1-byte: string length is at pos+1+4 = pos+5
+            if FPosition + 1 + 4 + 4 <= FCount then
+            begin
+              NextValue := 0;
+              Move(FData[FPosition + 1 + 4], NextValue, 4);
+              if (NextValue >= 0) and (NextValue < 10000) then
+                Use4Byte := False  // 1-byte path: valid string length
+              else
+                Use4Byte := True;  // neither makes sense, default to 4-byte
+            end
+            else
+              Use4Byte := True;
+          end;
+        end
+        else
+          Use4Byte := True;  // not enough data for deeper check, trust 4-byte
+      end
       else
       begin
         // Out-of-range 4-byte value. Check if 1-byte interpretation is valid.


### PR DESCRIPTION
Root cause: TFreeFileVersion is stored as 1 byte in files saved by older FreeShip builds (Delphi with {$Z1} enum packing), but current Free Pascal in {$MODE Delphi} reads SizeOf(TFreeFileVersion) = 4 bytes, consuming 3 extra bytes and misaligning all subsequent reads until EOF overrun.

Detection strategy in LoadTFreeFileVersion:
1. Read 4 bytes as tentative version ordinal
2. If value exceeds valid enum range (0..44), use 1-byte path
3. If value IS in range, lookahead at next 4 bytes (Precision field)
   - Valid Precision (0..3) confirms 4-byte path
   - Invalid Precision means our 4-byte read straddled two 1-byte fields
4. Fall back to 1-byte read when lookahead fails

Verified against 72 .fbm sample files spanning versions fv210-fv430, including edge cases where the 1-byte ordinal is small enough to appear valid as a 4-byte value (e.g. ellipsoid321.fbm, ordinal 22).

Note: Only TFreeFileVersion is affected. Precision is saved via Add(Ord(Precision)) which calls Add(integer) - always 4 bytes regardless of enum packing directive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Issue #111 by correctly reading 1‑byte `TFreeFileVersion` in older .fbm files. Also removes sizeof()-based record jumps so field reads/writes advance position naturally, preventing misalignment and EOF errors on imported files.

- **Bug Fixes**
  - Robust 1‑ vs 4‑byte detection: 4‑byte read + precision lookahead with fallback to 1‑byte, tiebreaker for out‑of‑range future versions, and a second lookahead on CreatedBy string length to resolve ambiguous cases.
  - Removed all bp + sizeof(Data) overrides in Load*/Add*; let per‑field I/O advance the cursor to avoid drift on Fastship/Rhino imports and cross‑version files.
  - Quotes 'TFreeFileVersion' in format() to fix a build break; scoped to 'TFreeFileVersion' only — Precision remains 4‑byte. Verified on 277 .fbm files.

<sup>Written for commit cdbb806dbf429146a896478c16e2bf471828e242. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

