### PR TITLE
feat(i18n): add initial Brazilian Portuguese (pt-BR) translation

### DIFF
--- a/locale/FreeShip.pt_BR.po
+++ b/locale/FreeShip.pt_BR.po
@@ -1,0 +1,12066 @@
+# FreeShip for Lazarus.
+# Copyright (C) 2024 Free Software Foundation, Inc.
+# MARK MALAKANOV <markmal@github.com>, 2024.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"PO-Revision-Date: 2026-06-11 21:10-0300\n"
+"Last-Translator:  <v@mainframe.localdomain>\n"
+"Language-Team: Brazilian Portuguese <ldpbr-"
+"translation@lists.sourceforge.net>\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: freecontrolpointfrm.rsangle
+msgctxt "freecontrolpointfrm.rsangle"
+msgid "Angle"
+msgstr ""
+
+#: freecontrolpointfrm.rsangles
+msgctxt "freecontrolpointfrm.rsangles"
+msgid "Angles"
+msgstr ""
+
+#: freecontrolpointfrm.rslength
+msgctxt "freecontrolpointfrm.rslength"
+msgid "Length"
+msgstr "Comprimento"
+
+#: freecontrolpointfrm.rsnameisnotunique
+msgid "Name Is Not Unique"
+msgstr ""
+
+#: freecontrolpointfrm.rspointnamechanged
+msgid "Point Name Changed"
+msgstr ""
+
+#: freecontrolpointfrm.rsxcoordinate
+msgid "X Coordinate"
+msgstr ""
+
+#: freecontrolpointfrm.rsycoordinate
+msgid "Y Coordinate"
+msgstr ""
+
+#: freecontrolpointfrm.rszcoordinate
+msgid "Z Coordinate"
+msgstr ""
+
+#: freecrosscurvesdlg.amplitude_of_heel_angle__2_0_degrees____
+msgid "Amplitude of heel angle <2.0 degrees !!!"
+msgstr ""
+
+#: freefilebuffer.rsparsingerroroutoffilesize
+#, object-pascal-format
+msgid ""
+"Error parsing of file \"%s\". Reading %s of size %d at position %d that is "
+"out of file size %d."
+msgstr ""
+
+#: freefilepreviewdialog.hintdblclicktofitsize
+msgid "DblClick to fit size"
+msgstr ""
+
+#: freefilepreviewdialog.hintdblclicktofullsize
+msgctxt "freefilepreviewdialog.hintdblclicktofullsize"
+msgid "DblClick to full size"
+msgstr ""
+
+#: freefilepreviewdialog.okbuttoncaptionopen
+msgctxt "freefilepreviewdialog.okbuttoncaptionopen"
+msgid "Open"
+msgstr ""
+
+#: freefilepreviewdialog.okbuttoncaptionsave
+msgctxt "freefilepreviewdialog.okbuttoncaptionsave"
+msgid "Save"
+msgstr ""
+
+#: freefilepreviewdialog.rscancelbuttoncaptioncancel
+msgctxt "freefilepreviewdialog.rscancelbuttoncaptioncancel"
+msgid "Cancel"
+msgstr ""
+
+#: freefilepreviewdialog.rsclicktoedit
+msgid "Click to edit"
+msgstr ""
+
+#: freefilepreviewdialog.rslocation_does_not_exist
+msgid "Location does not exist"
+msgstr ""
+
+#: freefilepreviewdialog.rsunableopenfilemsg
+#, object-pascal-format
+msgid "Unable open file \"%s\""
+msgstr ""
+
+#: freefilepreviewdialog.statusfailedtorename
+#, object-pascal-format
+msgid "Failed to rename \"%s\" to \"%s\""
+msgstr ""
+
+#: freefilepreviewdialog.statusnamealreadyexists
+#, object-pascal-format
+msgid "Name \"%s\" already exists"
+msgstr ""
+
+#: freefilepreviewdialog.statuswrongname
+#, object-pascal-format
+msgid "Wrong name \"%s\""
+msgstr ""
+
+#: freelinesplanfrme.exportdxf_filter
+msgctxt "freelinesplanfrme.exportdxf_filter"
+msgid "Autocad dxf file"
+msgstr ""
+
+#: freepropeller_task5dlg.rsnoresultfile
+#, object-pascal-format
+msgid "Result file \"%s\" not found"
+msgstr ""
+
+#: freeshellctrls.sshellctrlstime
+msgctxt "freeshellctrls.sshellctrlstime"
+msgid "Time"
+msgstr ""
+
+#: freeship.installmemessage
+msgid ""
+"Configuration issue.\n"
+"Scenario A: You probably run FreeShip from installation directory.\n"
+"FreeShip is not installed.\n"
+"It will work but it may experience issues with finding various files and "
+"directories.\n"
+"Please exit and run install-FreeShip.sh\n"
+"\n"
+"Scenario B: You probably have previously installed FreeShip in user scope "
+"and just re-installed it in machine scope, or vice versa.\n"
+"Please enter menu File/Preferences, Directories tab, and click Reset button\n"
+msgstr ""
+
+#: freeship.usageline01
+msgid "Usage: FreeShip [parameter]* [model]"
+msgstr ""
+
+#: freeship.usageline02
+msgid "Where parameter is:"
+msgstr ""
+
+#: freeship.usageline03
+msgid "--help        : this screen"
+msgstr ""
+
+#: freeship.usageline04
+msgid "--log-error   : log level is Error. Only Error messages logged"
+msgstr ""
+
+#: freeship.usageline05
+msgid ""
+"--log-warning : log level is Warning. Only Error and Warning messages logged"
+msgstr ""
+
+#: freeship.usageline06
+msgid ""
+"--log-info    : log level is Info. Error, Warning and Info messages logged"
+msgstr ""
+
+#: freeship.usageline07
+msgid "--log-debug   : log level is Debug. All messages logged."
+msgstr ""
+
+#: freeship.usageline08
+msgid "--log-file=<logfile> : filename of the log file"
+msgstr ""
+
+#: freeship.usageline09
+msgid ""
+"--nosplash-I-ACCEPT-GPLv3-TERMS-AND-CONDITIONS : turn off splash screen."
+msgstr ""
+
+#: freeship.usageline10
+msgid "--debug       : for development, use only when run in debugger"
+msgstr ""
+
+#: freeship.usageline11
+msgid "model         : model file .ftm or .fbm"
+msgstr ""
+
+#: freeshipunit.filedialogfilterall
+msgid "All|*"
+msgstr ""
+
+#: freeshipunit.filedialogfilterfreeship
+msgid "FreeShip files (*.ftm *.fbm)|*.ftm;*.fbm"
+msgstr ""
+
+#: freeshipunit.filedialogfilterfreeshipbinary
+msgid "FreeShip Binary (*.fbm)|*.fbm"
+msgstr ""
+
+#: freeshipunit.filedialogfilterfreeshiptext
+msgid "FreeShip Text (*.ftm)|*.ftm"
+msgstr ""
+
+#: freeshipunit.filedialogplaceglobalimport
+msgctxt "freeshipunit.filedialogplaceglobalimport"
+msgid "Global Import"
+msgstr ""
+
+#: freeshipunit.filedialogplaceglobalships
+msgid "Global Ships"
+msgstr ""
+
+#: freeshipunit.filedialogplacelast
+msgid "Last"
+msgstr ""
+
+#: freeshipunit.filedialogplacemyimport
+msgid "My Import"
+msgstr ""
+
+#: freeshipunit.filedialogplacemyships
+msgid "My Ships"
+msgstr ""
+
+#: freeshipunit.rs3dtextfile
+msgid "3D text file"
+msgstr ""
+
+#: freeshipunit.rsadd_massfiles
+msgid "Add_Mass files"
+msgstr ""
+
+#: freeshipunit.rsarchimedesmbmultibodyhulldata
+msgid "ArchimedesMB multi body hull data"
+msgstr ""
+
+#: freeshipunit.rsarchimedessinglebodyhulldata
+msgid "Archimedes single body hull data"
+msgstr ""
+
+#: freeshipunit.rsautocaddxffile
+msgctxt "freeshipunit.rsautocaddxffile"
+msgid "Autocad dxf file"
+msgstr ""
+
+#: freeshipunit.rscarenexyzfiles
+msgid "Carene XYZ files"
+msgstr ""
+
+#: freeshipunit.rscarlssonhullfiles
+msgid "Carlsson Hull files"
+msgstr ""
+
+#: freeshipunit.rsfailedtoloadproject
+#, object-pascal-format
+msgid ""
+"Failed to load project: %s\n"
+"Error: %s\n"
+msgstr ""
+
+#: freeshipunit.rsfreeshipbinaryfiles
+msgid "FreeShip Binary files"
+msgstr ""
+
+#: freeshipunit.rsfreeshipexchangeformat
+msgid "FREE!ship Exchange Format"
+msgstr ""
+
+#: freeshipunit.rsfreeshipexchangeformatfile
+msgid "FREE!ship Exchange Format file"
+msgstr ""
+
+#: freeshipunit.rsfreeshipfiles
+msgid "FreeShip files"
+msgstr ""
+
+#: freeshipunit.rsfreeshipgeometrypart
+msgid "FREE!ship geometry part"
+msgstr ""
+
+#: freeshipunit.rsfreeshiptextfiles
+msgid "FreeShip Text files"
+msgstr ""
+
+#: freeshipunit.rsghsfiles
+msgid "GHS files"
+msgstr ""
+
+#: freeshipunit.rsglobalconfigloaderrormessage
+msgid ""
+"Unable to load per-machine configuration. Skipping. There may be further "
+"problems with finding directories and files.\n"
+"Error:"
+msgstr ""
+
+#: freeshipunit.rsigesfiles
+msgid "IGES files"
+msgstr ""
+
+#: freeshipunit.rsmichletinputfile
+msgid "Michlet input file"
+msgstr ""
+
+#: freeshipunit.rsmichletwaveelevationsfile
+msgid "Michlet wave elevations file"
+msgstr ""
+
+#: freeshipunit.rspointanchorconstraintchanged
+msgid "ControlPoint Anchor Constraint Changed"
+msgstr ""
+
+#: freeshipunit.rspointlinearconstraintchanged
+msgid "ControlPoint Linear Constraint Changed"
+msgstr ""
+
+#: freeshipunit.rspointmove
+msgctxt "freeshipunit.rspointmove"
+msgid "point move"
+msgstr ""
+
+#: freeshipunit.rspolycadfiles
+msgid "PolyCad files"
+msgstr ""
+
+#: freeshipunit.rssavefile
+msgid "Save file"
+msgstr ""
+
+#: freeshipunit.rssavewithhigherfileversion
+#, object-pascal-format
+msgid ""
+"The current file version is %s.%sDo you want to save the file as version %s ?"
+msgstr ""
+
+#: freeshipunit.rssplitsection
+msgid "Split Section"
+msgstr ""
+
+#: freeshipunit.rsstlfile
+msgid "STL file"
+msgstr ""
+
+#: freeshipunit.rstextfile
+msgctxt "freeshipunit.rstextfile"
+msgid "Text file"
+msgstr ""
+
+#: freeshipunit.rstextfiles
+msgid "Text files"
+msgstr ""
+
+#: freeshipunit.rsthemeloaderrormessage
+#, object-pascal-format
+msgid ""
+"Unable to load theme %s\n"
+"Error:"
+msgstr ""
+
+#: freeshipunit.rsunablecreatebackupfile
+msgid "Unable to create backup file"
+msgstr ""
+
+#: freeshipunit.rsunabledeletebackupfile
+msgid "Unable to delete backup file"
+msgstr ""
+
+#: freeshipunit.rsunabletosavefile
+msgid "Unable to save file"
+msgstr ""
+
+#: freeshipunit.rsuserconfigloaderrormessage
+msgid ""
+"Unable to load per-user configuration. There may be further problems with "
+"finding directories and files. Using defaults.\n"
+"Error:"
+msgstr ""
+
+#: freeshipunit.rsvrmlfiles
+msgid "VRML files"
+msgstr ""
+
+#: freeshipunit.rswavefrontfile
+msgid "Wavefront file"
+msgstr ""
+
+#: freeshipunit.rs_cannotcreatedirectory
+msgid "Cannot create directory: "
+msgstr ""
+
+#: freesplashwndw.rsbuild
+msgctxt "freesplashwndw.rsbuild"
+msgid "Build"
+msgstr ""
+
+#: freesplashwndw.rsrelease
+msgctxt "freesplashwndw.rsrelease"
+msgid "Release"
+msgstr ""
+
+#: freesplashwndw.rsversion
+msgctxt "freesplashwndw.rsversion"
+msgid "Version"
+msgstr ""
+
+#: freestringsunit.rs_1_1_1_r_m_isherwood___wind__resistance_of__merchant__ships___proceedings__of__royal
+msgid ""
+"1.1.1 R.M.Isherwood, \"Wind  Resistance of  Merchant  Ships\", Proceedings  "
+"of  Royal"
+msgstr ""
+
+#: freestringsunit.rs_1_1___this_wind_resistance_prediction_method_in_this_program_has_been_described_by_
+msgid ""
+"1.1   This wind resistance prediction method in this program has been "
+"described by:"
+msgstr ""
+
+#: freestringsunit.rs_1_2___needed_input_data_parameters_
+msgid "1.2   Needed input data parameters:"
+msgstr ""
+
+#: freestringsunit.rs_1_min
+msgid "1/min"
+msgstr ""
+
+#: freestringsunit.rs_1__do_not_found_into__exec_or_was_damaged_file
+msgid "1. Do not found into \\Exec or was damaged file"
+msgstr ""
+
+#: freestringsunit.rs_2_screw_rudder_slender_thick
+msgid "2-screw rudder slender/thick"
+msgstr ""
+
+#: freestringsunit.rs_2__input_datas_are_outside_valid_domain_or_catalog_is_not_valid_
+msgid "2. Input datas are outside valid domain or catalog is not valid."
+msgstr ""
+
+#: freestringsunit.rs_3__this_is_very_slow_computer__fcpu___800_mhz_
+msgid "3. This is very slow computer, Fcpu < 800 MHz."
+msgstr ""
+
+#: freestringsunit.rs_4_brass_altmntfe__5_bronze_neva_60__6_bronze_neva_70__7_stainless_steel__8_duralumin_
+msgid ""
+"4-brass Al+Mn+Fe; 5-bronze Neva-60; 6-bronze Neva-70; 7-stainless steel; 8-"
+"duralumin."
+msgstr ""
+
+#: freestringsunit.rs_4__cpu_is_loaded_more_80__another_processes_
+msgid "4. CPU is loaded more 80% another processes."
+msgstr ""
+
+#: freestringsunit.rs_5_standart_deviation_of_database_for_typical_resistance_hollenbach_s_method_
+msgid ""
+"5.Standart deviation of database for typical resistance Hollenbach's method:"
+msgstr ""
+
+#: freestringsunit.rs_aae___
+msgid "AAE  ="
+msgstr ""
+
+#: freestringsunit.rs_acceleration_of_ship_calculation
+msgid "Acceleration of ship calculation"
+msgstr ""
+
+#: freestringsunit.rs_acceleration_of_ship_calculation_results
+msgid "Acceleration of ship calculation results"
+msgstr ""
+
+#: freestringsunit.rs_acceleration_time__min__sec__
+msgid "Acceleration time [min (sec)]"
+msgstr ""
+
+#: freestringsunit.rs_acceleration__free_and_active_brake_calculation_
+msgid "Acceleration, free and active brake calculation."
+msgstr ""
+
+#: freestringsunit.rs_according_to_john_winters
+msgid "according to John Winters"
+msgstr ""
+
+#: freestringsunit.rs_according_to_modeling_experiment
+msgid "according to modeling experiment"
+msgstr ""
+
+#: freestringsunit.rs_active_brake_of_ship_
+msgid "Active brake of ship."
+msgstr ""
+
+#: freestringsunit.rs_active_brake_of_ship_calculation__reverse_
+msgid "Active brake of ship calculation (reverse)"
+msgstr ""
+
+#: freestringsunit.rs_active_brake_of_ship_calculation__reverse__results
+msgid "Active brake of ship calculation (reverse) results"
+msgstr ""
+
+#: freestringsunit.rs_active_brake_time__min__sec__
+msgid "Active brake time [min (sec)]"
+msgstr ""
+
+#: freestringsunit.rs_added_masses_coefficients_for_riverships_
+msgid "Added masses Coefficients for riverships:"
+msgstr ""
+
+#: freestringsunit.rs_added_masses_coefficients_for_riverships_and_ships_with_cb____0_8_
+msgid "Added masses Coefficients for riverships and ships with Cb >= 0.8:"
+msgstr ""
+
+#: freestringsunit.rs_added_masses_coefficients_for_seaships_by_folmulae__4__
+msgid "Added masses Coefficients for seaships by folmulae [4]:"
+msgstr ""
+
+#: freestringsunit.rs_added_masses_of_a_ship_
+msgid "Added masses of a ship:"
+msgstr ""
+
+#: freestringsunit.rs_added_masses_of_equivalent_ellipsoid_body__3__
+msgid "Added masses of equivalent ellipsoid body [3]:"
+msgstr ""
+
+#: freestringsunit.rs_additional_calculations_
+msgid "Additional calculations:"
+msgstr ""
+
+#: freestringsunit.rs_add_cylinder
+msgid "Add cylinder"
+msgstr ""
+
+#: freestringsunit.rs_add_flowline
+msgid "Add flowline"
+msgstr ""
+
+#: freestringsunit.rs_add_multiple_buttocks
+msgid "Add multiple buttocks"
+msgstr ""
+
+#: freestringsunit.rs_add_multiple_diagonals
+msgid "Add multiple diagonals"
+msgstr ""
+
+#: freestringsunit.rs_add_multiple_stations
+msgid "Add multiple stations"
+msgstr ""
+
+#: freestringsunit.rs_add_multiple_waterlines
+msgid "Add multiple waterlines"
+msgstr ""
+
+#: freestringsunit.rs_add_one_buttock
+msgid "Add one buttock"
+msgstr ""
+
+#: freestringsunit.rs_add_one_diagonal
+msgid "Add one diagonal"
+msgstr ""
+
+#: freestringsunit.rs_add_one_station
+msgid "Add one station"
+msgstr ""
+
+#: freestringsunit.rs_add_one_waterline
+msgid "Add one waterline"
+msgstr ""
+
+#: freestringsunit.rs_advance_coefficient
+msgid "Advance Coefficient"
+msgstr ""
+
+#: freestringsunit.rs_advance_coefficient_jp
+msgid "Advance coefficient Jp"
+msgstr ""
+
+#: freestringsunit.rs_advance_coefficient_j____________________
+msgid "Advance Coefficient J                   ="
+msgstr ""
+
+#: freestringsunit.rs_advance_of_central_hull_a__mm
+msgid "Advance of central hull A, mm"
+msgstr ""
+
+#: freestringsunit.rs_aerodynamic_characteristics_of_a_merchant_ship
+msgid "Aerodynamic characteristics of a merchant ship"
+msgstr ""
+
+#: freestringsunit.rs_aerodynamic_coefficients_cx__cy__10ocmz
+msgid "Aerodynamic coefficients Cx, Cy, 10*Cmz"
+msgstr ""
+
+#: freestringsunit.rs_aerodynamic_forces_and_moment_without_drift_
+msgid "Aerodynamic forces and moment without drift:"
+msgstr ""
+
+#: freestringsunit.rs_ae_aooo___1_3_you_must_to_increase_dp_
+msgid "Ae/Ao** > 1.3 You must to increase Dp."
+msgstr ""
+
+#: freestringsunit.rs_ae_ao_is_out_of_limits_for_this_diagram___
+msgid "Ae/Ao is out of limits for this diagram!!!"
+msgstr ""
+
+#: freestringsunit.rs_al11__al22__al33__
+msgid "al11, al22, al33 ="
+msgstr ""
+
+#: freestringsunit.rs_al44__al55__al66__
+msgid "al44, al55, al66 ="
+msgstr ""
+
+#: freestringsunit.rs_align_points
+msgid "align points"
+msgstr ""
+
+#: freestringsunit.rs_all_of_the_selected_points_are_locked_and_cannot_be_moved
+msgid "All of the selected points are locked and cannot be moved"
+msgstr ""
+
+#: freestringsunit.rs_al_____lateral_projected_wind_area__m2__
+msgid "AL   - Lateral projected wind area [m2];"
+msgstr ""
+
+#: freestringsunit.rs_amplitude_of_roll
+msgid "Amplitude of roll"
+msgstr ""
+
+#: freestringsunit.rs_analyze_surface
+msgid "analyze surface"
+msgstr ""
+
+#: freestringsunit.rs_and
+msgid "and"
+msgstr ""
+
+#: freestringsunit.rs_and_cannot_be_opened_with_this_version
+msgid "and cannot be opened with this version"
+msgstr ""
+
+#: freestringsunit.rs_angle
+msgctxt "freestringsunit.rs_angle"
+msgid "Angle"
+msgstr ""
+
+#: freestringsunit.rs_angles
+msgctxt "freestringsunit.rs_angles"
+msgid "Angles"
+msgstr ""
+
+#: freestringsunit.rs_angle_between_relative_velocity_and_center_line__degr__
+msgid "Angle between relative velocity and center line [degr.]"
+msgstr ""
+
+#: freestringsunit.rs_angle_between_thrust_and_keel_lines
+msgctxt "freestringsunit.rs_angle_between_thrust_and_keel_lines"
+msgid "Angle between Thrust and Keel lines"
+msgstr "Ângulo entre as linhas de Empuxo e Quilha"
+
+#: freestringsunit.rs_angle_of
+msgid "ANGLE OF"
+msgstr ""
+
+#: freestringsunit.rs_angle_of_attack__degr_
+msgctxt "freestringsunit.rs_angle_of_attack__degr_"
+msgid "Angle of attack [degr]"
+msgstr ""
+
+#: freestringsunit.rs_angle_of_heel_psi
+msgid "Angle of heel Psi"
+msgstr ""
+
+#: freestringsunit.rs_angle_of_rel_wind_off_bow__degr__
+msgid "Angle of rel wind off bow [degr.]"
+msgstr ""
+
+#: freestringsunit.rs_angle_of_trim
+msgid "Angle of trim"
+msgstr ""
+
+#: freestringsunit.rs_angle_vs_buttoks_about_10__
+msgid "Angle vs buttoks about 10°"
+msgstr ""
+
+#: freestringsunit.rs_angle_vs_buttoks_about_20__
+msgid "Angle vs buttoks about 20°"
+msgstr ""
+
+#: freestringsunit.rs_apparent__relative__wind_speed__m_s_
+msgid "Apparent (relative) wind speed [m/s]"
+msgstr ""
+
+#: freestringsunit.rs_appendages_areas_
+msgid "Appendages areas:"
+msgstr "Áreas dos apêndices:"
+
+#: freestringsunit.rs_appendage_coefficient
+msgctxt "freestringsunit.rs_appendage_coefficient"
+msgid "Appendage coefficient"
+msgstr ""
+
+#: freestringsunit.rs_appen__drag____bare_hull_resistance_____
+msgid "Appen. Drag (% Bare Hull Resistance)   ="
+msgstr ""
+
+#: freestringsunit.rs_area
+msgctxt "freestringsunit.rs_area"
+msgid "Area"
+msgstr ""
+
+#: freestringsunit.rs_areas_of_keels
+msgid "Areas of keels"
+msgstr ""
+
+#: freestringsunit.rs_areas_of_rudders
+msgid "Areas of rudders"
+msgstr ""
+
+#: freestringsunit.rs_are_you_sure_you_want_to_continue_
+msgid "Are you sure you want to continue?"
+msgstr ""
+
+#: freestringsunit.rs_are_you_sure_you_want_to_delete_all_the_markers_
+msgid "Are you sure you want to delete all the markers?"
+msgstr ""
+
+#: freestringsunit.rs_are_you_sure_you_want_to_delete_the
+msgid "Are you sure you want to delete the"
+msgstr ""
+
+#: freestringsunit.rs_are_you_sure_you_want_to_delete_this_background_image_
+msgid "Are you sure you want to delete this background image?"
+msgstr ""
+
+#: freestringsunit.rs_are_you_sure_you_want_to_quit
+msgid "Are you sure you want to quit"
+msgstr ""
+
+#: freestringsunit.rs_are_you_sure_you_want_to_reset_the_preferences
+msgid "Are you sure you want to reset the preferences"
+msgstr ""
+
+#: freestringsunit.rs_as_____lateral_projected_area_of_superstructure__m2__
+msgid "AS   - Lateral projected area of superstructure [m2];"
+msgstr ""
+
+#: freestringsunit.rs_attention__weight_of_a_ship_and_displacement_are_difference_more_then_10___
+msgid ""
+"Attention: Weight of a ship and displacement are difference more then 10% !"
+msgstr ""
+
+#: freestringsunit.rs_attention____
+msgid "ATTENTION!!!_"
+msgstr ""
+
+#: freestringsunit.rs_attention____calculated_diameter_of_propeller_is_bigger_then_limited_diameter_dp_lim_
+msgid ""
+"ATTENTION!!! Calculated diameter of propeller is bigger then limited "
+"diameter Dp_lim="
+msgstr ""
+
+#: freestringsunit.rs_attention____calculation_for_sea_vessels_by_holtrop_1988_method_
+msgid "ATTENTION!!! Calculation for sea vessels by Holtrop-1988 method."
+msgstr ""
+
+#: freestringsunit.rs_attention____ho__
+msgid "ATTENTION!!! ho ="
+msgstr ""
+
+#: freestringsunit.rs_attention____increase_number_of_propellers_or_decrease_estimate_speed_
+msgid "ATTENTION!!! Increase number of propellers or decrease estimate speed."
+msgstr ""
+
+#: freestringsunit.rs_attention____limit_of_power_in_freeware_free_shipt_is_reached___
+msgid "ATTENTION!!! Limit of power in freeware Free!ship+ is reached!!!"
+msgstr ""
+
+#: freestringsunit.rs_attention____l_max__
+msgid "ATTENTION!!! l_max <"
+msgstr ""
+
+#: freestringsunit.rs_attention____porpoising_regime____
+msgid "ATTENTION!!! Porpoising regime !!!"
+msgstr ""
+
+#: freestringsunit.rs_attention____stopped_acceleration_calculation__because_steady_engine_rpm
+msgid ""
+"ATTENTION!!! Stopped acceleration calculation, because steady engine RPM"
+msgstr ""
+
+#: freestringsunit.rs_attention____teta0___60_
+msgid "ATTENTION!!! Teta0 < 60°"
+msgstr ""
+
+#: freestringsunit.rs_attention____the_number_of_propeller_diagram_more_then_11_is_accessed_in_pro_version_only___
+msgid ""
+"ATTENTION!!! The number of propeller diagram more then 11 is accessed in Pro "
+"version only!!!"
+msgstr ""
+
+#: freestringsunit.rs_attention____the_power_of_engine_is_very_high_
+msgid "ATTENTION!!! The power of engine is very high!"
+msgstr ""
+
+#: freestringsunit.rs_attention____the_power_of_engine_is_very_low_
+msgid "ATTENTION!!! The power of engine is very low!"
+msgstr ""
+
+#: freestringsunit.rs_attention____the_waiting_speed_is_outside_valid_domain_of_calculated_speed___
+msgid ""
+"ATTENTION!!! The waiting speed is outside valid domain of calculated speed!!!"
+msgstr ""
+
+#: freestringsunit.rs_attention____this_is_diagram_of_propeller_accessed_in_pro_version_only___
+msgid ""
+"ATTENTION!!! This is diagram of propeller accessed in Pro version only!!!"
+msgstr ""
+
+#: freestringsunit.rs_attention____this_is_propeller_with_cavitation_
+msgid "ATTENTION!!! This is propeller with cavitation!"
+msgstr ""
+
+#: freestringsunit.rs_attention____this_is_series_not_correct_for_this_project_
+msgid "ATTENTION!!! This is series NOT correct for this project!"
+msgstr ""
+
+#: freestringsunit.rs_attention_____power_is_out_valid_domain_30_____400_bhp_per_unit_for_used_diagram_
+msgid ""
+"ATTENTION !!! Power is out valid domain 30 ... 400 BHP per unit for used "
+"diagram."
+msgstr ""
+
+#: freestringsunit.rs_attention_____vs_is_out_valid_domain_0_____40_knots_for_used_diagram_
+msgid "ATTENTION !!! Vs is out valid domain 0 ... 40 knots for used diagram."
+msgstr ""
+
+#: freestringsunit.rs_at_least_two_layers_are_needed_to_perform_this_operation_
+msgid "At least two layers are needed to perform this operation."
+msgstr ""
+
+#: freestringsunit.rs_average_chordlength
+msgctxt "freestringsunit.rs_average_chordlength"
+msgid "Average chordlength"
+msgstr ""
+
+#: freestringsunit.rs_background_image_settings
+msgid "Background image settings"
+msgstr ""
+
+#: freestringsunit.rs_base
+msgid "Base"
+msgstr ""
+
+#: freestringsunit.rs_beam_on_waterline
+msgid "Beam on waterline"
+msgstr "Boca na linha d'água"
+
+#: freestringsunit.rs_beam_over_all
+msgid "Beam over all"
+msgstr "Boca máxima (total)"
+
+#: freestringsunit.rs_because_cwp_0__this_wetted_area_is_not_right___
+msgid "Because Cwp=0, this wetted area is NOT right!!!"
+msgstr ""
+
+#: freestringsunit.rs_because_extrapolation_is_used__can_be_some_errores_
+msgid "Because extrapolation is used, can be some errores."
+msgstr ""
+
+#: freestringsunit.rs_bhp
+msgid "BHP"
+msgstr ""
+
+#: freestringsunit.rs_bilge_keels
+msgctxt "freestringsunit.rs_bilge_keels"
+msgid "Bilge keels"
+msgstr ""
+
+#: freestringsunit.rs_bilge_keels_area
+msgid "Bilge keels area"
+msgstr ""
+
+#: freestringsunit.rs_block_coefficient
+msgctxt "freestringsunit.rs_block_coefficient"
+msgid "Block coefficient"
+msgstr "Coeficiente de Bloco"
+
+#: freestringsunit.rs_block_coefficient_on_lwl____________cb__
+msgid "Block Coefficient on LWL            CB ="
+msgstr ""
+
+#: freestringsunit.rs_bodyplan_view
+msgid "Bodyplan view"
+msgstr ""
+
+#: freestringsunit.rs_brake_power__kw_______________pb__
+msgid "Brake power [kW]              Pb ="
+msgstr ""
+
+#: freestringsunit.rs_breadth______________________________br__
+msgid "BREADTH ............................ BR :"
+msgstr ""
+
+#: freestringsunit.rs_bulbous_characteristics
+msgid "Bulbous characteristics"
+msgstr ""
+
+#: freestringsunit.rs_bulbous_coefficient
+msgid "Bulbous coefficient"
+msgstr ""
+
+#: freestringsunit.rs_bulb_area_on_fp
+msgid "Bulb area on FP"
+msgstr ""
+
+#: freestringsunit.rs_bulb_section_area_at_station_0__m_2_____
+msgid "Bulb Section Area at Station 0 (m^2)   ="
+msgstr ""
+
+#: freestringsunit.rs_burrill_back_cavitation_constraint_____
+msgid "Burrill Back Cavitation Constraint    ="
+msgstr ""
+
+#: freestringsunit.rs_buttock
+msgid "Buttock"
+msgstr "Linha do alto"
+
+#: freestringsunit.rs_buttocks
+msgctxt "freestringsunit.rs_buttocks"
+msgid "Buttocks"
+msgstr "Linhas do alto"
+
+#: freestringsunit.rs_bwl_tc_is_outside_valid_domain
+msgid "Bwl/Tc is outside valid domain"
+msgstr ""
+
+#: freestringsunit.rs_by
+msgid "by"
+msgstr ""
+
+#: freestringsunit.rs_by_a_diagram_of_64_series
+msgid "by a diagram of 64 series"
+msgstr ""
+
+#: freestringsunit.rs_by_a_diagram_of_braun
+msgid "by a diagram of Braun"
+msgstr ""
+
+#: freestringsunit.rs_by_a_diagram_of_de_groot
+msgid "by a diagram of de Groot"
+msgstr ""
+
+#: freestringsunit.rs_by_a_diagram_of_neyman
+msgid "by a diagram of Neyman"
+msgstr ""
+
+#: freestringsunit.rs_by_a_diagram_of_nordstrom
+msgid "by a diagram of Nordstrom"
+msgstr ""
+
+#: freestringsunit.rs_by_a_diagram_of_npl
+msgid "by a diagram of NPL"
+msgstr ""
+
+#: freestringsunit.rs_by_a_diagram_of_sspa
+msgid "by a diagram of SSPA"
+msgstr ""
+
+#: freestringsunit.rs_by_a_diagram_of_volodin
+msgid "by a diagram of Volodin"
+msgstr ""
+
+#: freestringsunit.rs_by_a_method_holtrop_1988
+msgid "by a method Holtrop-1988"
+msgstr ""
+
+#: freestringsunit.rs_by_a_method_of_doubrovsky
+msgid "by a method of Doubrovsky"
+msgstr ""
+
+#: freestringsunit.rs_by_a_method_of_niewt__russia_
+msgid "by a method of NIEWT (Russia)"
+msgstr ""
+
+#: freestringsunit.rs_by_benge_afanasiev_formulae
+msgid "by Benge-Afanasiev formulae"
+msgstr ""
+
+#: freestringsunit.rs_by_benhe_s_formulae
+msgid "by Benhe's formulae"
+msgstr ""
+
+#: freestringsunit.rs_by_clement_blount_1963_method
+msgid "by Clement-Blount 1963 method"
+msgstr ""
+
+#: freestringsunit.rs_by_clement_poup_1961_method
+msgid "by Clement-Poup 1961 method"
+msgstr ""
+
+#: freestringsunit.rs_by_compton_1986_method
+msgid "by Compton-1986 method"
+msgstr ""
+
+#: freestringsunit.rs_by_danckwardt_1969_formulae
+msgid "by Danckwardt-1969 formulae"
+msgstr ""
+
+#: freestringsunit.rs_by_d_savitsky
+msgid "by D.Savitsky"
+msgstr ""
+
+#: freestringsunit.rs_by_fung_leibman_s_method_1995
+msgid "by Fung-Leibman's method 1995"
+msgstr ""
+
+#: freestringsunit.rs_by_grigoriev_formulae
+msgid "by Grigoriev formulae"
+msgstr ""
+
+#: freestringsunit.rs_by_hard_chine_catamarans_regression_method
+msgid "by hard-chine catamarans regression method"
+msgstr ""
+
+#: freestringsunit.rs_by_hollenbach_1998
+msgid "by Hollenbach-1998"
+msgstr ""
+
+#: freestringsunit.rs_by_karpov_s_formulae
+msgid "by Karpov's formulae"
+msgstr ""
+
+#: freestringsunit.rs_by_lap_1954_formulae
+msgid "by Lap-1954 formulae"
+msgstr ""
+
+#: freestringsunit.rs_by_methods_niewt__giewt_and_liwt__russia_
+msgid "by methods NIEWT, GIEWT and LIWT (Russia)"
+msgstr ""
+
+#: freestringsunit.rs_by_method_of_doubrovin
+msgid "by method of Doubrovin"
+msgstr ""
+
+#: freestringsunit.rs_by_method_of_geers
+msgid "by method of Geers"
+msgstr ""
+
+#: freestringsunit.rs_by_method_of_yeroshin
+msgid "by method of Yeroshin"
+msgstr ""
+
+#: freestringsunit.rs_by_moomford_s_formulae
+msgid "by Moomford's formulae"
+msgstr ""
+
+#: freestringsunit.rs_by_muragin_s_formulae
+msgid "by Muragin's formulae"
+msgstr ""
+
+#: freestringsunit.rs_by_m_bunkov_method
+msgid "by M.Bunkov method"
+msgstr ""
+
+#: freestringsunit.rs_by_oct_5_0181_75__xussr_
+msgid "by OCT 5.0181-75 (xUSSR)"
+msgstr ""
+
+#: freestringsunit.rs_by_papmehl_s_formulae_with_addings_of_ksri__russia_
+msgid "by Papmehl's formulae with addings of KSRI (Russia)"
+msgstr ""
+
+#: freestringsunit.rs_by_radojcic_1985_method
+msgid "by Radojcic-1985 method"
+msgstr ""
+
+#: freestringsunit.rs_by_ridgeley_nevitt_1967_method
+msgid "by Ridgeley-Nevitt-1967 method"
+msgstr ""
+
+#: freestringsunit.rs_by_robinson_1999_method
+msgid "by Robinson-1999 method"
+msgstr ""
+
+#: freestringsunit.rs_by_russian_registry_for_sea_ships
+msgid "by Russian Registry for sea ships"
+msgstr ""
+
+#: freestringsunit.rs_by_schneekluth_1988_formulae
+msgid "by Schneekluth-1988 formulae"
+msgstr ""
+
+#: freestringsunit.rs_by_semeka_s_formulae
+msgid "by Semeka's formulae"
+msgstr ""
+
+#: freestringsunit.rs_by_ubc_1993_method
+msgid "by UBC-1993 method"
+msgstr ""
+
+#: freestringsunit.rs_by_van_oortmerssen_1971_formulae
+msgid "by van Oortmerssen-1971 formulae"
+msgstr ""
+
+#: freestringsunit.rs_by_van_oortmerssen_1971_method
+msgid "by van Oortmerssen-1971 method"
+msgstr ""
+
+#: freestringsunit.rs_by_vashedchenko_1985_formulae
+msgid "by Vashedchenko-1985 formulae"
+msgstr ""
+
+#: freestringsunit.rs_by_yeroshin_s_formulae
+msgid "by Yeroshin's formulae"
+msgstr ""
+
+#: freestringsunit.rs_b______beam__m__
+msgid "B    - Beam [m];"
+msgstr ""
+
+#: freestringsunit.rs_caclulation_added_ssd_parameters_by_gims__russia__
+msgid "Caclulation added SSD parameters by GIMS (Russia):"
+msgstr ""
+
+#: freestringsunit.rs_calculated_frv_
+msgid "Calculated FrV="
+msgstr ""
+
+#: freestringsunit.rs_calculated_variables
+msgid "Calculated variables"
+msgstr ""
+
+#: freestringsunit.rs_calculations_of_resistance_and_power_by_d_savitsky_method
+msgid "Calculations of resistance and power by D.Savitsky method"
+msgstr ""
+
+#: freestringsunit.rs_calculations_of_resistance_and_power_for_planing_ships_by_lyubomirov_i_p__formulaes
+msgid ""
+"Calculations of resistance and power for planing ships by Lyubomirov I.P. "
+"formulaes"
+msgstr ""
+
+#: freestringsunit.rs_calculations_of_resistance_and_power_for_planing_ships_by_sedov_l_i__method
+msgid ""
+"Calculations of resistance and power for planing ships by Sedov L.I. method"
+msgstr ""
+
+#: freestringsunit.rs_calculation_aborted
+msgid "Calculation aborted"
+msgstr ""
+
+#: freestringsunit.rs_calculation_is_not_possible_with_this_data____
+msgid "Calculation is NOT possible with this data !!!"
+msgstr ""
+
+#: freestringsunit.rs_calculation_is_not_possible__because_l_b_2____
+msgid "Calculation is NOT possible, because L/B<2 !!!"
+msgstr ""
+
+#: freestringsunit.rs_calculation_of_open_water_characteristics_of_a_propeller
+msgid "CALCULATION OF OPEN WATER CHARACTERISTICS OF A PROPELLER"
+msgstr ""
+
+#: freestringsunit.rs_calculation_of_passport_diagram
+msgid "Calculation of passport diagram"
+msgstr ""
+
+#: freestringsunit.rs_calculation_of_propeller_for_selected_engine
+msgid "Calculation of propeller for selected engine"
+msgstr ""
+
+#: freestringsunit.rs_calculation_of_propeller_is_stop__because_np_set_zero_in_resistance_calculation_
+msgid ""
+"Calculation of propeller is stop, because Np set zero in resistance "
+"calculation!"
+msgstr ""
+
+#: freestringsunit.rs_calculation_of_propeller_on_cavitation_by_a_method_of_papmehl_
+msgid "Calculation of propeller on cavitation by a method of Papmehl:"
+msgstr ""
+
+#: freestringsunit.rs_calculation_of_propeller_on_cavitation_by_s_hoenherr_s_method_
+msgid "Calculation of propeller on cavitation by SÃÂ±hoenherr's method:"
+msgstr ""
+
+#: freestringsunit.rs_calculation_of_propeller_on_general_strength_for_r_d_0_3_
+msgid "Calculation of propeller on general strength for r/D=0.3:"
+msgstr ""
+
+#: freestringsunit.rs_calculation_of_resistance_for_keeled_yacht_by_holtrop_s_method_is_impossible___
+msgid ""
+"Calculation of resistance for keeled yacht by Holtrop's method is "
+"impossible!!!"
+msgstr ""
+
+#: freestringsunit.rs_calculation_of_the_propeller_elements_for_main_engine_selection
+msgid "Calculation of the propeller elements for main engine selection"
+msgstr ""
+
+#: freestringsunit.rs_calculation_of_wind_coefficients_of_a_ship
+msgid "CALCULATION OF WIND COEFFICIENTS OF A SHIP"
+msgstr ""
+
+#: freestringsunit.rs_calculation_optimal_elements_of_propeller_for_engine_selection
+msgid "Calculation optimal elements of propeller for engine selection"
+msgstr ""
+
+#: freestringsunit.rs_calculation_ssd__dsd_and_weather_criteria_is_available_in_metric_system_
+msgid ""
+"Calculation SSD, DSD and weather criteria is available in metric system!"
+msgstr ""
+
+#: freestringsunit.rs_cavitation_number_sigma__________________
+msgid "Cavitation Number Sigma                 ="
+msgstr ""
+
+#: freestringsunit.rs_center
+msgid "Center"
+msgstr ""
+
+#: freestringsunit.rs_centerline
+msgid "Centerline"
+msgstr ""
+
+#: freestringsunit.rs_center_of_buoyancy_lcb__m_from_fp_______
+msgid "Center of Buoyancy LCB (m from FP)     ="
+msgstr "Centro de Carena LCB (m da PV)           ="
+
+#: freestringsunit.rs_center_of_buoyancy_lcb____lwl__t_fwd____
+msgid "Center of Buoyancy LCB (% LWL; + Fwd)  ="
+msgstr "Centro de Carena LCB (% LWL; + Vante)    ="
+
+#: freestringsunit.rs_centimeters
+msgid "Centimeters"
+msgstr ""
+
+#: freestringsunit.rs_choose_a_directory_where_you_want_to_save_the_dxf_files_to_
+msgid "Choose a directory where you want to save the dxf files to:"
+msgstr ""
+
+#: freestringsunit.rs_click_button_for_start_selection_of_engine
+msgid "Click button for start selection of engine"
+msgstr ""
+
+#: freestringsunit.rs_close_hull
+msgid "Close hull"
+msgstr ""
+
+#: freestringsunit.rs_coef_infl_nonuniform_on_thrust
+msgid "Coef.infl.nonuniform on thrust"
+msgstr ""
+
+#: freestringsunit.rs_coef_infl_nonuniform_on_torque
+msgid "Coef.infl.nonuniform on torque"
+msgstr ""
+
+#: freestringsunit.rs_coef_infl__hull_on_diameter
+msgid "Coef.infl. hull on diameter"
+msgstr ""
+
+#: freestringsunit.rs_cog_x_of_fp_area
+msgid "CoG X of FP area"
+msgstr ""
+
+#: freestringsunit.rs_cog_z_bulb_area
+msgid "CoG Z bulb area"
+msgstr ""
+
+#: freestringsunit.rs_collapse_point
+msgid "collapse point"
+msgstr ""
+
+#: freestringsunit.rs_comment
+msgctxt "freestringsunit.rs_comment"
+msgid "Comment"
+msgstr ""
+
+#: freestringsunit.rs_comparison_by_resistance
+msgid "Comparison by resistance"
+msgstr ""
+
+#: freestringsunit.rs_computing_time
+msgid "Computing time"
+msgstr ""
+
+#: freestringsunit.rs_conference_on_hydrodynamics_of_high_speed_craft__rina__nov__1999
+msgid "Conference on Hydrodynamics of High Speed Craft, RINA, Nov. 1999"
+msgstr ""
+
+#: freestringsunit.rs_controlface_s__could_be_removed_
+msgid "controlface(s) could be removed."
+msgstr ""
+
+#: freestringsunit.rs_controllable_reversible_pitch_propeller
+msgid "Controllable-Reversible-Pitch Propeller"
+msgstr "Hélice de Passo Controlável-Reversível"
+
+#: freestringsunit.rs_controlpoints_s__could_be_removed_
+msgid "controlpoints(s) could be removed."
+msgstr ""
+
+#: freestringsunit.rs_corner
+msgid "corner"
+msgstr ""
+
+#: freestringsunit.rs_corrected_metacentric_height
+msgid "Corrected metacentric height"
+msgstr ""
+
+#: freestringsunit.rs_corresponds_to_category_navigation
+msgid "Corresponds to category navigation"
+msgstr ""
+
+#: freestringsunit.rs_could_not_calculate_limitpoint
+msgid "Could not calculate limitpoint"
+msgstr ""
+
+#: freestringsunit.rs_could_not_export_surfaces_
+msgid "Could not export surfaces."
+msgstr ""
+
+#: freestringsunit.rs_could_not_find_edge
+msgid "Could not find edge"
+msgstr ""
+
+#: freestringsunit.rs_could_not_find_the_interior_point_
+msgid "Could not find the interior point!"
+msgstr ""
+
+#: freestringsunit.rs_could_not_load_program_preferences_from_the_following_location
+msgid "Could not load program preferences from the following location"
+msgstr ""
+
+#: freestringsunit.rs_could_not_open_the_file_
+msgid "Could not open the file."
+msgstr ""
+
+#: freestringsunit.rs_could_not_save_program_preferences_to_the_following_location
+msgid "Could not save program preferences to the following location"
+msgstr ""
+
+#: freestringsunit.rs_cpp_in_nozzle_e_series
+msgid "CPP in nozzle E series"
+msgstr ""
+
+#: freestringsunit.rs_cp_is_outside_valid_domain
+msgid "Cp is outside valid domain"
+msgstr ""
+
+#: freestringsunit.rs_created_by
+msgid "Created by"
+msgstr ""
+
+#: freestringsunit.rs_cross_curves
+msgctxt "freestringsunit.rs_cross_curves"
+msgid "Cross curves"
+msgstr ""
+
+#: freestringsunit.rs_curves
+msgid "curves"
+msgstr ""
+
+#: freestringsunit.rs_cx_drag___cy_lift___m_z__cd__0_1ok
+msgid "Cx(Drag), Cy(Lift), m_z, Cd, 0.1*K"
+msgstr ""
+
+#: freestringsunit.rs_data_for_propulsion_saved_
+msgid "Data for propulsion saved!"
+msgstr ""
+
+#: freestringsunit.rs_date
+msgid "Date"
+msgstr ""
+
+#: freestringsunit.rs_deadrise_amidships
+msgid "Deadrise amidships"
+msgstr ""
+
+#: freestringsunit.rs_deck_house_cargo_frontal_area__m_2______
+msgid "Deck House/Cargo Frontal Area (m^2)    ="
+msgstr ""
+
+#: freestringsunit.rs_degr
+msgid "degr"
+msgstr ""
+
+#: freestringsunit.rs_delete
+msgid "delete"
+msgstr ""
+
+#: freestringsunit.rs_delete_all_buttocks
+msgid "Delete all buttocks"
+msgstr ""
+
+#: freestringsunit.rs_delete_all_diagonals
+msgid "Delete all diagonals"
+msgstr ""
+
+#: freestringsunit.rs_delete_all_stations
+msgid "Delete all stations"
+msgstr ""
+
+#: freestringsunit.rs_delete_all_waterlines
+msgid "Delete all waterlines"
+msgstr ""
+
+#: freestringsunit.rs_delete_empty_layers
+msgid "delete empty layers"
+msgstr ""
+
+#: freestringsunit.rs_delete_markers
+msgid "delete markers"
+msgstr ""
+
+#: freestringsunit.rs_depth_at_the_bow__m_____________________
+msgid "Depth at the Bow (m)                   ="
+msgstr ""
+
+#: freestringsunit.rs_depth_of_shaft_below_waterline__m______
+msgid "Depth of Shaft below Waterline (m)    ="
+msgstr "Prof. do Eixo abaixo da Linha D'água (m) ="
+
+#: freestringsunit.rs_designer
+msgctxt "freestringsunit.rs_designer"
+msgid "Designer"
+msgstr ""
+
+#: freestringsunit.rs_design_beam
+msgid "Design beam"
+msgstr ""
+
+#: freestringsunit.rs_design_draft
+msgid "Design draft"
+msgstr ""
+
+#: freestringsunit.rs_design_length
+msgid "Design length"
+msgstr ""
+
+#: freestringsunit.rs_design_margin_has_been_included_in_rt__pe__and_req_thr___rt__1_t__
+msgid "Design Margin Has Been Included in RT, PE, and REQ.THR = RT/(1-t)."
+msgstr ""
+
+#: freestringsunit.rs_design_margin_on_rt_pe_req_thr__________
+msgid "Design Margin on RT,PE,REQ.THR (%)     ="
+msgstr ""
+
+#: freestringsunit.rs_diagonal
+msgid "Diagonal"
+msgstr ""
+
+#: freestringsunit.rs_diagonals
+msgctxt "freestringsunit.rs_diagonals"
+msgid "Diagonals"
+msgstr ""
+
+#: freestringsunit.rs_diameter_of_propeller__m_
+msgid "Diameter of propeller [m]"
+msgstr ""
+
+#: freestringsunit.rs_difference_of_midship_draft
+msgid "Difference of midship draft"
+msgstr ""
+
+#: freestringsunit.rs_disk_area_ratio_ae_ao
+msgctxt "freestringsunit.rs_disk_area_ratio_ae_ao"
+msgid "Disk area ratio Ae/Ao"
+msgstr ""
+
+#: freestringsunit.rs_displaced_volume
+msgid "Displaced volume"
+msgstr ""
+
+#: freestringsunit.rs_displacement
+msgctxt "freestringsunit.rs_displacement"
+msgid "Displacement"
+msgstr "Deslocamento"
+
+#: freestringsunit.rs_displacement_step_can_not_be_zero_
+msgid "Displacement step can not be zero."
+msgstr "O passo de deslocamento não pode ser zero."
+
+#: freestringsunit.rs_distance
+msgctxt "freestringsunit.rs_distance"
+msgid "Distance"
+msgstr ""
+
+#: freestringsunit.rs_distance_between_centerplans_s__m
+msgid "Distance between centerplans S, m"
+msgstr ""
+
+#: freestringsunit.rs_distance_between_the_hulls__m
+msgid "Distance between the hulls, m"
+msgstr ""
+
+#: freestringsunit.rs_distance_between_thrust_line_and_cog
+msgid "Distance between Thrust line and CoG"
+msgstr ""
+
+#: freestringsunit.rs_distance_from_bow_to_centroid_________c__
+msgid "DISTANCE FROM BOW TO CENTROID ....... C :"
+msgstr ""
+
+#: freestringsunit.rs_distance_from_bow__fp__to_wind_area_cog
+msgid "Distance from bow (FP) to wind area CoG"
+msgstr ""
+
+#: freestringsunit.rs_distance_from_wind_area_cog_to_dwl
+msgid "Distance from wind area CoG to DWL"
+msgstr ""
+
+#: freestringsunit.rs_distance__miles___speed__knots___frequency_of_propeller_no0_1__1_min_
+msgid "Distance [miles]; Speed [knots]; Frequency of propeller n*0.1 [1/min]"
+msgstr ""
+
+#: freestringsunit.rs_distance__sea_miles__m__
+msgid "Distance [sea miles (m)]"
+msgstr ""
+
+#: freestringsunit.rs_dome_area
+msgid "Dome area"
+msgstr ""
+
+#: freestringsunit.rs_double_edges
+msgid "double edges"
+msgstr ""
+
+#: freestringsunit.rs_do_not_calculate_this_task__because_
+msgid "Do NOT calculate this task, because:"
+msgstr ""
+
+#: freestringsunit.rs_do_not_have_results_of_resistance_calculation_in_this_directory_
+msgid "Do not have results of resistance calculation in this directory!"
+msgstr ""
+
+#: freestringsunit.rs_do_not_resistance_calculation_results_of_a_ship___
+msgid "Do not resistance calculation results of a ship!!!"
+msgstr ""
+
+#: freestringsunit.rs_do_not_set_main_dimensions_lpp__b_and_t____
+msgid "Do not set main dimensions Lpp, B and T !!!"
+msgstr ""
+
+#: freestringsunit.rs_do_you_want_to_adjust_the_markers_too
+msgid "Do you want to adjust the markers too"
+msgstr ""
+
+#: freestringsunit.rs_do_you_want_to_import_the_intermediate_bulkheads_
+msgid "Do you want to import the intermediate bulkheads?"
+msgstr ""
+
+#: freestringsunit.rs_do_you_want_to_replace_it_with_another_one_
+msgid "Do you want to replace it with another one?"
+msgstr ""
+
+#: freestringsunit.rs_do_you_want_to_save_it_first_
+msgid "Do you want to save it first?"
+msgstr ""
+
+#: freestringsunit.rs_do_you_want_to_save_the_file_as_version
+msgid "Do you want to save the file as version"
+msgstr ""
+
+#: freestringsunit.rs_dpr___
+msgid "DPR  ="
+msgstr ""
+
+#: freestringsunit.rs_draft_aft__m____________________________
+msgid "Draft Aft (m)                          ="
+msgstr "Calado a Ré (m)                          ="
+
+#: freestringsunit.rs_draft_forward__m________________________
+msgid "Draft Forward (m)                      ="
+msgstr "Calado a Vante (m)                       ="
+
+#: freestringsunit.rs_draft_hull
+msgctxt "freestringsunit.rs_draft_hull"
+msgid "Draft hull"
+msgstr "Calado do casco"
+
+#: freestringsunit.rs_draft_on_f_a_
+msgid "Draft on F.A."
+msgstr "Calado na P.R. (Perpendicular a Ré)"
+
+#: freestringsunit.rs_draft_on_f_p_
+msgid "Draft on F.P."
+msgstr "Calado na P.V. (Perpendicular a Vante)"
+
+#: freestringsunit.rs_draft_on_midship
+msgid "Draft on midship"
+msgstr "Calado a meia-nau"
+
+#: freestringsunit.rs_drag_force__kn_
+msgid "Drag force [kN]"
+msgstr ""
+
+#: freestringsunit.rs_dwl
+msgid "DWL"
+msgstr ""
+
+#: freestringsunit.rs_edges
+msgid "edges"
+msgstr ""
+
+#: freestringsunit.rs_edges_found_with_more_then_2_faces_connected_to_it_
+msgid "edges found with more then 2 faces connected to it!"
+msgstr ""
+
+#: freestringsunit.rs_edge_already_exists
+msgid "Edge already exists"
+msgstr ""
+
+#: freestringsunit.rs_edge_collapse
+msgid "edge collapse"
+msgstr ""
+
+#: freestringsunit.rs_edge_extrusion
+msgid "edge extrusion"
+msgstr ""
+
+#: freestringsunit.rs_edge_split
+msgid "edge split"
+msgstr ""
+
+#: freestringsunit.rs_effective_waterline_length
+msgid "Effective waterline length"
+msgstr ""
+
+#: freestringsunit.rs_efficiency_of_gearbox
+msgid "Efficiency of gearbox"
+msgstr ""
+
+#: freestringsunit.rs_efficiency_of_shaft
+msgctxt "freestringsunit.rs_efficiency_of_shaft"
+msgid "Efficiency of shaft"
+msgstr ""
+
+#: freestringsunit.rs_efficiency___________________eta__
+msgid "Efficiency                   Eta ="
+msgstr ""
+
+#: freestringsunit.rs_empty_layers_deleted
+msgid "empty layers deleted"
+msgstr ""
+
+#: freestringsunit.rs_ended_frequency_engine_shaft__1_min__1_s__
+msgid "Ended frequency engine shaft [1/min (1/s)]"
+msgstr ""
+
+#: freestringsunit.rs_ended_speed__knots__m_s__
+msgid "Ended speed [knots (m/s)]"
+msgstr ""
+
+#: freestringsunit.rs_end_speed
+msgctxt "freestringsunit.rs_end_speed"
+msgid "End speed"
+msgstr ""
+
+#: freestringsunit.rs_engine_power__kw_
+msgid "Engine power [kW]"
+msgstr ""
+
+#: freestringsunit.rs_enter_the_printscale
+msgid "Enter the printscale"
+msgstr ""
+
+#: freestringsunit.rs_error_in_line
+msgid "Error in line"
+msgstr ""
+
+#: freestringsunit.rs_error_reading_from_file
+msgid "Error reading from file"
+msgstr ""
+
+#: freestringsunit.rs_error_while_assembling_triangle_
+msgid "Error while assembling triangle!"
+msgstr ""
+
+#: freestringsunit.rs_error__cp_1_or_cwp_1
+msgid "Error: Cp=1 or Cwp=1"
+msgstr ""
+
+#: freestringsunit.rs_error__lwl_90m_or_lwl__4m
+msgid "Error: Lwl>90m or Lwl<=4m"
+msgstr ""
+
+#: freestringsunit.rs_error_____s___bwl____
+msgid "Error ==> S < Bwl !!!"
+msgstr ""
+
+#: freestringsunit.rs_estimated
+msgid "Estimated"
+msgstr ""
+
+#: freestringsunit.rs_estimated_advance_____________jp__
+msgid "Estimated advance             Jp ="
+msgstr ""
+
+#: freestringsunit.rs_estimated_displacement_d
+msgid "Estimated displacement D"
+msgstr ""
+
+#: freestringsunit.rs_estimated_frv_
+msgid "Estimated FrV="
+msgstr ""
+
+#: freestringsunit.rs_estimated_power_engine___kw___bhp______
+msgid "Estimated Power Engine, [kW]([bhp])   ="
+msgstr ""
+
+#: freestringsunit.rs_expanded_area_ratio_ae_ao________________
+msgid "Expanded Area Ratio Ae/Ao               ="
+msgstr ""
+
+#: freestringsunit.rs_exposed_shafts_area_
+msgid "Exposed shafts area:"
+msgstr ""
+
+#: freestringsunit.rs_faces
+msgid "faces"
+msgstr ""
+
+#: freestringsunit.rs_feet
+msgid "Feet"
+msgstr ""
+
+#: freestringsunit.rs_filename
+msgctxt "freestringsunit.rs_filename"
+msgid "Filename"
+msgstr ""
+
+#: freestringsunit.rs_file_hship_exe_is_not_exists_or_damaged___
+msgid "File hship.exe is not exists or damaged!!!"
+msgstr ""
+
+#: freestringsunit.rs_file_resist_cnf_is_not_exists_or_damaged___
+msgid "File Resist.cnf is not exists or damaged!!!"
+msgstr ""
+
+#: freestringsunit.rs_final_calculations_of_resistance_and_power_by_clement_blount_s_method
+msgid "Final calculations of resistance and power by Clement-Blount's method"
+msgstr ""
+
+#: freestringsunit.rs_final_calculations_of_resistance_and_power_by_clement_poup_s_method
+msgid "Final calculations of resistance and power by Clement-Poup's method"
+msgstr ""
+
+#: freestringsunit.rs_final_calculations_of_resistance_and_power_by_compton_s_method
+msgid "Final calculations of resistance and power by Compton's method"
+msgstr ""
+
+#: freestringsunit.rs_final_calculations_of_resistance_and_power_by_mercier_and_savitsky_s_method
+msgid ""
+"Final calculations of resistance and power by Mercier and Savitsky's method"
+msgstr ""
+
+#: freestringsunit.rs_final_calculations_of_resistance_and_power_by_method_fung_leibman_1995
+msgid "Final calculations of resistance and power by method Fung-Leibman 1995"
+msgstr ""
+
+#: freestringsunit.rs_final_calculations_of_resistance_and_power_by_method_hollenbach_1998
+msgid "Final calculations of resistance and power by method Hollenbach-1998"
+msgstr ""
+
+#: freestringsunit.rs_final_calculations_of_resistance_and_power_by_method_van_oortmerssen_1971
+msgid ""
+"Final calculations of resistance and power by method van Oortmerssen-1971"
+msgstr ""
+
+#: freestringsunit.rs_final_calculations_of_resistance_and_power_by_m_bunkov_method
+msgid "Final calculations of resistance and power by M.Bunkov method"
+msgstr ""
+
+#: freestringsunit.rs_final_calculations_of_resistance_and_power_by_radojcic_s_method
+msgid "Final calculations of resistance and power by Radojcic's method"
+msgstr ""
+
+#: freestringsunit.rs_final_calculations_of_resistance_and_power_by_ridgeley_nevitt_1967_method
+msgid ""
+"Final calculations of resistance and power by Ridgeley-Nevitt-1967 method"
+msgstr ""
+
+#: freestringsunit.rs_final_calculations_of_resistance_and_power_by_robinson_s_method
+msgid "Final calculations of resistance and power by Robinson's method"
+msgstr ""
+
+#: freestringsunit.rs_final_calculations_of_resistance_and_power_by_ubc_1993_method
+msgid "Final calculations of resistance and power by UBC-1993 method"
+msgstr ""
+
+#: freestringsunit.rs_final_calculations_of_resistance_and_power_for_planing_ships
+msgid "Final calculations of resistance and power for planing ships"
+msgstr ""
+
+#: freestringsunit.rs_final_calculations_of_resistance_and_power_prediction_by
+msgid "Final calculations of resistance and power prediction by"
+msgstr ""
+
+#: freestringsunit.rs_final_calculations_of_resistance_by
+msgid "Final calculations of resistance by"
+msgstr ""
+
+#: freestringsunit.rs_final_calculations_of_resistance_by_a_method_holtrop_1988
+msgid "Final calculations of resistance by a method Holtrop-1988"
+msgstr ""
+
+#: freestringsunit.rs_fixed_pitch_propeller
+msgid "Fixed-Pitch Propeller"
+msgstr "Hélice de Passo Fixo"
+
+#: freestringsunit.rs_flip_normals
+msgid "flip normals"
+msgstr ""
+
+#: freestringsunit.rs_for
+msgid "for"
+msgstr ""
+
+#: freestringsunit.rs_forward_line_with_dwl_
+msgid "forward line with DWL."
+msgstr ""
+
+#: freestringsunit.rs_for_calculation_is_in_free_ship_directory___
+msgid "for calculation is in Free!Ship directory!!!"
+msgstr ""
+
+#: freestringsunit.rs_for_d_
+msgid "for D="
+msgstr ""
+
+#: freestringsunit.rs_for_megayachts_formulae
+msgid "for megayachts formulae"
+msgstr ""
+
+#: freestringsunit.rs_for_ship_with_transom
+msgid "for ship with transom"
+msgstr ""
+
+#: freestringsunit.rs_fpp_in_nozzle_kaplan_series
+msgid "FPP in nozzle Kaplan series"
+msgstr ""
+
+#: freestringsunit.rs_fpp_in_nozzle_spp_series
+msgid "FPP in nozzle SPP series"
+msgstr ""
+
+#: freestringsunit.rs_fpp_in_nozzle_vit_series
+msgid "FPP in nozzle VIT series"
+msgstr ""
+
+#: freestringsunit.rs_free_brake_of_ship_
+msgid "Free brake of ship."
+msgstr ""
+
+#: freestringsunit.rs_free_brake_of_ship_calculation
+msgid "Free brake of ship calculation"
+msgstr ""
+
+#: freestringsunit.rs_free_brake_of_ship_calculation_results
+msgid "Free brake of ship calculation results"
+msgstr ""
+
+#: freestringsunit.rs_free_brake_time__min__sec__
+msgid "Free brake time [min (sec)]"
+msgstr ""
+
+#: freestringsunit.rs_free_ship_linesplan
+msgid "FREE!ship linesplan"
+msgstr ""
+
+#: freestringsunit.rs_free_ship_plate_developments
+msgid "FREE!ship plate developments"
+msgstr ""
+
+#: freestringsunit.rs_frequency__1_min_
+msgid "Frequency [1/min]"
+msgstr ""
+
+#: freestringsunit.rs_freq__of_propeller_rotation__1_min_
+msgid "Freq. of propeller rotation [1/min]"
+msgstr ""
+
+#: freestringsunit.rs_frv_is_outside_valid_domain_1_____4___used_extrapolation_for_r_ap
+msgid "FrV is outside valid domain 1 ... 4 , used extrapolation for R_ap"
+msgstr ""
+
+#: freestringsunit.rs_ft
+msgid "ft"
+msgstr ""
+
+#: freestringsunit.rs_ft_2
+msgid "ft^2"
+msgstr ""
+
+#: freestringsunit.rs_ft_2_s
+msgid "ft^2/s"
+msgstr ""
+
+#: freestringsunit.rs_ft_3
+msgid "ft^3"
+msgstr ""
+
+#: freestringsunit.rs_ft_4
+msgid "ft^4"
+msgstr ""
+
+#: freestringsunit.rs_general
+msgctxt "freestringsunit.rs_general"
+msgid "General"
+msgstr ""
+
+#: freestringsunit.rs_generalized_longitudinal_metacentric_height_h
+msgid "Generalized longitudinal metacentric height H"
+msgstr ""
+
+#: freestringsunit.rs_generalized_transverse__metacentric__height_h
+msgid "Generalized transverse  metacentric  height h"
+msgstr ""
+
+#: freestringsunit.rs_gzd_for_zg_
+msgid "GZd for Zg="
+msgstr ""
+
+#: freestringsunit.rs_gz_for_zg_
+msgid "GZ for Zg="
+msgstr ""
+
+#: freestringsunit.rs_gz_psi_
+msgid "GZ(Psi)"
+msgstr ""
+
+#: freestringsunit.rs_gz___m___gzd____m_
+msgid "GZ, [m]; GZd,  [m]"
+msgstr ""
+
+#: freestringsunit.rs_half_angle_of_entrance__deg_____________
+msgid "Half Angle of Entrance (deg)           ="
+msgstr ""
+
+#: freestringsunit.rs_half_entrance_angle_of_dwl
+msgid "Half entrance angle of DWL"
+msgstr ""
+
+#: freestringsunit.rs_have_not_file
+msgid "Have not file"
+msgstr ""
+
+#: freestringsunit.rs_have_not_input_file_for_calculation_is_here___
+msgid "Have not input file for calculation is here!!!"
+msgstr ""
+
+#: freestringsunit.rs_heeling_angle_at_which_righting_lever_0_again
+msgid "Heeling angle at which righting lever=0 again"
+msgstr ""
+
+#: freestringsunit.rs_heeling_angle_for_constant_wind_speed
+msgid "Heeling angle for constant wind speed"
+msgstr ""
+
+#: freestringsunit.rs_heeling_angle_for_gz_maximum
+msgid "Heeling angle for GZ maximum"
+msgstr ""
+
+#: freestringsunit.rs_heeling_angle___degr_
+msgctxt "freestringsunit.rs_heeling_angle___degr_"
+msgid "Heeling angle, [degr]"
+msgstr "Ângulo de adernamento (banda) [graus]"
+
+#: freestringsunit.rs_holtrop_1988_method
+msgid "Holtrop-1988 method"
+msgstr ""
+
+#: freestringsunit.rs_hull
+msgctxt "freestringsunit.rs_hull"
+msgid "Hull"
+msgstr "Casco"
+
+#: freestringsunit.rs_hull_bossing_area
+msgid "Hull bossing area"
+msgstr "Área do bojo do casco"
+
+#: freestringsunit.rs_hull_characteristics_above_waterline
+msgid "Hull characteristics above waterline"
+msgstr ""
+
+#: freestringsunit.rs_hydrodin_maneuv_note
+msgid ""
+"Maneuvering Prediction Program (MPP-1.3)\n"
+"M. G. Parsons, December, 1994\n"
+"1. METHODS:\n"
+"1.1  This program offers two main options: Linear Evaluation which "
+"implements the\n"
+"methods proposed by Clarke, Gedling, and Hine (1) for the  assessment  of  "
+"course\n"
+"stability,  turning  ability,  and  controllability  by  a  helmsman; and "
+"Turning\n"
+"Prediction which  implements  the  multiple linear regression equations "
+"presented\n"
+"by Lyster and Knights (2) for the estimation of turning circle "
+"characteristics.\n"
+"1.2  The  user should consult the Clarke paper prior to using the program. "
+"If the\n"
+"Linear  Evaluation option is used, the user can also obtain the linearized "
+"maneu-\n"
+"vering equations of motion in state variable form (3).\n"
+"1.3  In the Linear Evaluation option, the linear derivatives are estimated "
+"using\n"
+"the multiple linear regression equations presented by Clarke et al (1). The "
+"velo-\n"
+"city derivatives  were obtained from 72 sets of data from rotating arm and "
+"planar\n"
+"motion  tests.  Acceleration  derivatives  were  obtained from planar motion "
+"test\n"
+"data. The  independent  variables  include  T/LWL, CB*B/T, B/LWL, and B/T. "
+"Clarke\n"
+"feels  that  these  results  are  at  least  as  effective  as the semi-"
+"empirical\n"
+"equations developed by Wagner Smitt, Norrbin, or  Inoue. Water  depth "
+"corrections\n"
+"were added  by  regressing  the  data  presented by Fugino (4) for the Tokyo "
+"Maru\n"
+"( CB = 0.805 ) and the  Mariner ( CB = 0.589 ). Independent  variables  in  "
+"these\n"
+"analyses were CB and inverse powers of F = (H/T) -1. These  can be used for "
+"water\n"
+"depths down to H/T= 1.3, but are considered unreliable below this value. The "
+"trim\n"
+"corrections presented by Inoue (5) are used  for  the  velocity  "
+"derivatives. The\n"
+"independent variable  in  these corrections  is the trim to mean draft "
+"ratio. The\n"
+"various  time  constants  and  gains  in  the  first-  and  second-order "
+"Nomoto's\n"
+"equations are calculated from the linear derivatives.\n"
+"1.4  The quantities calculated to allow evaluation of the maneuvering "
+"performance\n"
+"of the vessels are as follows:\n"
+"1.4.1 Inverse time  constant (1/T')  and  inverse  gain  (1/K'). Turning  "
+"ability\n"
+"increases  with  decreasing 1/K' while course stability and quickness of "
+"response\n"
+"to helm increases with 1/T'.\n"
+"1.4.2 Clarke's turning index P.This quantity is derived from the linear "
+"equations\n"
+"as  the  amount  of  turn achieved in one ship length using a unit step "
+"rudder. A\n"
+"minimum value of 0.3 (equivalent to about 10 degrees for a 35 degree step "
+"rudder,\n"
+"within the  limits  of  the  linearized  equations of motion) is recommended "
+"with\n"
+"values as low as 0.2 considered acceptable for large tankers.\n"
+"1.4.3 Bare hull  dynamic  stability  criterion C. This must be positive for "
+"open-\n"
+"loop, controls-fixed course stability of the bare hull.\n"
+"1.4.4 Phase margin applicable to the closed-loop steering system.The phase "
+"margin\n"
+"of the ship transfer function, including the steering gear, is calculated. "
+"Nomoto\n"
+"notes  that  by  anticipating  the  shipÂs  turning, a typical helmsman can "
+"apply\n"
+"between 20 and 30 degrees of phase advance.  Thus, the  ship  with  steering "
+"gear\n"
+"cannot have more than this amount of negative phase margin  for  the  "
+"combination\n"
+"of the ship and helmsman to be closed-loop stable on course. Thus, a phase "
+"margin\n"
+"greater than about -20 degrees is recommended for reasonable human control.\n"
+"1.5 All  output  is  nondimensional  following Clarke (1) except the phase "
+"margin\n"
+"which is expressed in degrees.\n"
+"1.6 In the completely independent Turning Prediction option, the regression "
+"equa-\n"
+"tions developed by Lyster and Knights (2) from sea trial results are used "
+"to  es-\n"
+"timate turning  characteristics for a user-input rudder angle and approach "
+"speed.\n"
+"The  dependence  of the turns of single screw ships on the direction of "
+"propeller\n"
+"rotation and the ratio of the mean draft to the design draft were not "
+"implemented.\n"
+"1.7 The option produces estimates of the following:\n"
+"- steady turning diameter (meters)\n"
+"- tactical diameter (meters)\n"
+"- advance (meters)\n"
+"- transfer (meters)\n"
+"- steady speed in the turn (knots)\n"
+"1.8  This model is for  deep water and includes no dependence on water "
+"depth. The\n"
+"range of the ship parameters included in regression data set is as follows:\n"
+"+-------------+-------------------+-------------------------+\n"
+"| Parameter   |   Single screw    |       Twin screw        |\n"
+"+-------------+-------------------+-------------------------+\n"
+"|     Lpp     |  54,9 ... 329,2 m |    76,2 ... 225,6 m     |\n"
+"|     Cb      |  0,56 ... 0,87    |    0,42 ... 0,62        |\n"
+"|rudder angle |  10,0 ... 45 degr.|    10,0 ... 35 degr.    |\n"
+"|     L/B     |  5,56 ... 9,09    |    5,00 ... 16,67       |\n"
+"|   trim/Lpp  |  0,00 ... 0,05    |   -0,01 ... 0,03        |\n"
+"|     AR      |  0,01 ... 0,04    | 0,01 ... 0,02 per rudder|\n"
+"|     AB      | -0,11 ... 0,04    |   -0,10 ... 0,0         |\n"
+"|     Fr      |  0,06 ... 0,298   |   0,074 ... 0,655       |\n"
+"+-------------+-------------------+-------------------------+\n"
+"This model should be used with CAUTION outside this range.\n"
+"2.   INPUT:\n"
+"2.1  The input to MPP is through a series as follows:\n"
+"- LWL length on waterline in meters\n"
+"- B maximum beam on waterline in meters\n"
+"- TF draft forward in meters\n"
+"- TA draft aft in meters\n"
+"- CB block coefficient on LWL\n"
+"- LCG longitudinal center of gravity in %LWL from amidships; + forward\n"
+"- GYRAD yaw radius of gyration k33 as a fraction of LWL; default value 0.25\n"
+"- AB difference between the submerged bow profile area  on  the  "
+"centerplane  and\n"
+"that of a plumb bow as fraction of LWL*T; i.e.,AB = area forward of STA0/"
+"(LWL*T),\n"
+"positive when a bulbous bow projects forward of  the  forward  "
+"perpendicular,  or\n"
+"AB = cutaway  area  aft  of  STA0/(LWL*T), negative  with a raked stem or "
+"cutaway\n"
+"forefoot.\n"
+"2.2  Steering Characteristics obtains the rudder area, steering gear  time  "
+"cons-\n"
+"tant, position of the rudder center of effort (typically the 1/4 chord point "
+"from\n"
+"the leading edge), and selection of single or twin screw. The rudder area "
+"can  be\n"
+"input either as a fraction of LWL*T or automatically as the minumum  rudder  "
+"area\n"
+"specified  by  Det  Norske  Veritas for commercial vessels. For single "
+"screw, the\n"
+"sterm  type  must  be  designated  as a closed or open stern. For twin "
+"screw, the\n"
+"number of rudders must be designated as one or two.\n"
+"2.2.1  AR total rudder  area  as fraction of LWL*T; i.e., AR = A/(LWL*T);  "
+"option\n"
+"is calculated from the Det Norske Veritas minimum rudder area\n"
+"2.2.2  TE steering gear time constant in seconds; default value is 2.5 s\n"
+"2.2.3  XR center of effort of rudder in %LWL from amidships;+ aft;i.e.,about "
+"49.0\n"
+"2.3    Operating Conditions obtains the water depth and the initial vessel "
+"speed.\n"
+"2.3.1  H/T water depth to ship draft ratio (H/T); input 1000 for deep water\n"
+"2.3.2  VK initial or reference ship speed in knots\n"
+"3. REFERENCES:\n"
+"1. Clarke  D., Gedling  P., and Hine  G., \"The Application of Manoevring "
+"Criteria\n"
+"in Hull Design Using Linear Theory\", Transactions RINA, Vol. 124, 1982.\n"
+"2. Lyster  C. A., and Knights  H. L., \"Prediction  Equations  for  Ships' "
+"Turning\n"
+"Circles\", Transactions NECIES 1978-1979.\n"
+"3. Parsons M. G., \"Informal  Notes for NA530 Automatic Control in Naval "
+"Architec-\n"
+"ture  and  Marine  Engineering\", Vol. I, \"Classical Control,\" and Vol. II "
+"\"Modern\n"
+"Control.\"\n"
+"4. Fugino  M., \"Maneuverability in Restricted Waters: State of the Art\", "
+"The Uni-\n"
+"versity of Michigan NAME Report No. 184, Aug., 1976.\n"
+"5. Inoue, S., Hirano, M., and Kijima, K., \"Hydrodynamic Derivatives on Ship "
+"Mano-\n"
+"evring\", International Shipbuilding Progress, Vol. 28, No. 321, 1981."
+msgstr ""
+
+#: freestringsunit.rs_hydrodin_rvrs_note
+msgid ""
+"Table. Characteristics of sea ships diesels\n"
+"+----------------------+-----------------+------------------+----------------"
+"+\n"
+"|                      |      Power      |  Freq. of rotate | Inertia moment "
+"|\n"
+"|  Type of diesel      +-----------------+------------------+----------------"
+"+\n"
+"|                      |       kW        |      1/min       |     kg*m^2     "
+"|\n"
+"+----------------------+-----------------+------------------+----------------"
+"+\n"
+"| 6ДКРН 45/120-7       |      3970       |       170        |       70       "
+"|\n"
+"| 8ДКРН 45/120-7       |      5290       |       170        |       90       "
+"|\n"
+"| 6ДКРН 67/170-7       |      9630       |       123        |      446       "
+"|\n"
+"| 7ДКРН 67/170-7       |     11240       |       123        |      508       "
+"|\n"
+"| 6ДКРН 67/195-10      |      9150       |       111        |      550       "
+"|\n"
+"| 8ДКРН 67/195-10      |     12200       |       111        |      711       "
+"|\n"
+"| 6ЧРН 36/45(Г70)      |       883       |       375        |      512       "
+"|\n"
+"|                      |       736       |       350        |      512       "
+"|\n"
+"|                      |       662       |       375        |      512       "
+"|\n"
+"| 8ЧСПН18/22-475       |       370       |       750        |       20       "
+"|\n"
+"| 8ЧСПН18/22-315       |       230       |       750        |       20       "
+"|\n"
+"| 6ЧСПН18/22-300       |       220       |       750        |       25       "
+"|\n"
+"| 6ЧСПН18/22-225       |       165       |       750        |     18,3       "
+"|\n"
+"|   6ЧСП18/22          |       110       |       750        |     18,3       "
+"|\n"
+"| 12ЧНС18/22 (М401А-1) |       736       |      1550        |      4,9       "
+"|\n"
+"| 12ЧНС18/22 (М416)    |       808       |      1550        |      3,9       "
+"|\n"
+"| 12ЧН15/18(3КД12Н-520)|       380       |      1500        |      3,7       "
+"|\n"
+"| 12ЧСП15/18 (3Д12)    |       220       |      1500        |      8,7       "
+"|\n"
+"| 6ЧСПН15/18 (3Д6Н-235)|       170       |      1500        |      8,2       "
+"|\n"
+"| 6ЧСП15/18 (3Д6)      |       110       |      1500        |      8,5       "
+"|\n"
+"| 6ЧСП12/14 (К-161)    |        66       |      1500        |      4,0       "
+"|\n"
+"| 8ЧРН32/48(8НВД48А-2У)|       970       |       428        |      760       "
+"|\n"
+"|                      |       770       |       350        |      760       "
+"|\n"
+"| 6ЧРН32/48(6НВД48А-2У)|       736       |       428        |      700       "
+"|\n"
+"|                      |       640       |       375        |      700       "
+"|\n"
+"|                      |       515       |       300        |      700       "
+"|\n"
+"| 8ЧР32/48 (8НВД48-2У) |       647       |       428        |      760       "
+"|\n"
+"|                      |       490       |       350        |      760       "
+"|\n"
+"| 6ЧР32/48 (6НВД48-2У) |       485       |       428        |      700       "
+"|\n"
+"|                      |       370       |       375        |      700       "
+"|\n"
+"|                      |       294       |       300        |      700       "
+"|\n"
+"| 6ЧРН32/48 (6НВД48АУ) |       486       |       330        |      670       "
+"|\n"
+"| 8ЧРН24/36(8НВД36А-1У)|       425       |       500        |      117       "
+"|\n"
+"|8ЧНСП24/36(8ВД36/24А1)|       441       |       500        |      123       "
+"|\n"
+"|6ЧНСП27,5/36(6Л275ШПН)|       515       |       600        |      150       "
+"|\n"
+"| 6ЧРН36/50 (6Л350ПН)  |       721       |       375        |      670       "
+"|\n"
+"+----------------------+-----------------+------------------+----------------"
+"+"
+msgstr ""
+
+#: freestringsunit.rs_hydrodin_task1_note
+msgid ""
+"Program of aerodynamics characteristics calculation for merchant ships.\n"
+"1.1   This wind resistance prediction method in this program has been "
+"described by:\n"
+"1.1.1 R.M.Isherwood, \"Wind  Resistance of  Merchant  Ships\", Proceedings  "
+"of  Royal\n"
+"Institution of Naval Architects, 1973.\n"
+"1.2   Needed input data parameters:\n"
+"SLOA - Length overall [m];\n"
+"B    - Beam [m];\n"
+"AL   - Lateral projected wind area [m2];\n"
+"AS   - Lateral projected area of superstructure [m2];\n"
+"AT   - Transverse projected wind area [m2];\n"
+"S    - Length of perimeter of lateral projection, excluding WL and slender "
+"bodies;\n"
+"C    - Distance from bow to centroid of lateral projected area (m);\n"
+"M    - Number of distinct groups of masts or king posts;\n"
+"1.2.1   Number of groups of masts M:\n"
+"1  - Passenger ships and ferries;\n"
+"2  - Cargo ships with engines amidships, load;\n"
+"3  - Cargo ships with engines amidships, ballast;\n"
+"4  - Cargo ships with engines aft, load;\n"
+"5  - Cargo ships with engines aft, ballast;\n"
+"6  - Tankers and ore carriers with bridge amidships, load;\n"
+"7  - Tankers and ore carriers with bridge amidships, ballast;\n"
+"8  - Tankers and ore carriers with bridge aft, load;\n"
+"9  - Tankers and ore carriers with bridge aft, ballast;\n"
+"10 - Stern trawlers;\n"
+"11 - Tugs;\n"
+"12 - Tankers, bulkcariers, cargo ships with engines aft;\n"
+"13 - Passenger ships, ferries, container ships with cargo on deck;\n"
+"14 - Lichter ships with cargo on deck;\n"
+"15 - Lichter ships with out cargo.\n"
+"1.3    Output data:\n"
+"Cx = Fx/(0.5*RHOA*Vr^2*AT)+-1.96*Stand_Err(X)    - longitudinal force "
+"coefficient;\n"
+"Cy = Fy/(0.5*RHOA*Vr^2*AT)+-1.96*Stand_Err(Y)    - lateral force "
+"coefficient;\n"
+"Cmz= Mz/(0.5*RHOA*Vr^2*AT*SLOA)+-1.96*Stand_Err(Mz) - yawing moment "
+"coefficient,\n"
+"RHOA - density of air;\n"
+"Vr   - RMS of relative wind speed between water level and top of "
+"superstructure."
+msgstr ""
+
+#: freestringsunit.rs_hydrodin_task2_note
+msgctxt "freestringsunit.rs_hydrodin_task2_note"
+msgid ""
+"PROPELLER OPTIMIZATION PROGRAM (POP.1.5)\n"
+"M. G. Parsons, December, 1994\n"
+"1. METHODS:\n"
+"1.1    This program implements the Wageningen B-Screw Series regression "
+"equations presented\n"
+"by Oosterveld and van Oossanen [1]. The user can  either  evaluate a given "
+"propeller or use\n"
+"mathematical programming from Parsons [2] to  obtain  the  optimum  open  "
+"water  efficiency\n"
+"propeller for a given application.\n"
+"1.2   In the optimization mode, the user specifies the required thrust and "
+"speed of advance.\n"
+"The program then uses the Nelder and Mead Simplex Search method with  an  "
+"External  Penalty\n"
+"Function [2] to  determine  the  optimum  propeller. Wageningen  B-Screw  "
+"Series 3- through\n"
+"7-bladed propellers with Reynolds  number  corrections  are  available. "
+"Optimization  among\n"
+"blade number must be handled with separate runs for  each  blade  number  "
+"and  then  simple\n"
+"comparison. For  controllable-reversible-pitch  propeller  estimates, the  "
+"program  reduces\n"
+"the B-Screw Series open water efficiency  by 2 percent. The  program  "
+"includes  either  the\n"
+"Burrill five or ten percent back  cavitation  criterion [3]. The  "
+"optimization  independent\n"
+"variables are the expanded  area  ratio  Ae/Ao, the  pitch-diameter  ratio  "
+"P/Dp,  and  the\n"
+"propeller diameter Dp. The propeller RPM needed to produce  the  specified  "
+"thrust  (within\n"
+"about 1 lbf.) is determined at each step of the search in an internal loop. "
+"Thus,instead of\n"
+"having  RPM  as a fourth independent variable, it is established by the "
+"equality constraint\n"
+"that the produced  thrust must equal the required thrust. This is an "
+"implicit constraint so\n"
+"the required RPM is found by an iteration. The constraints on the variables "
+"are as follows:\n"
+"__3 <= Nblade <= 7;\n"
+"0.3 <=  Ae/Ao <= 1.05;\n"
+"0.5 <=  P/Dp  <= 1.40;\n"
+"Dpmin <= Dp   <= Dpmax;\n"
+"0.0  <=   J   <= 1.60;\n"
+"1 <= thrust loading <= 2 - by Burrill 5% or 10% limit.\n"
+"\n"
+"1.4 The optimization is for the maximum open water  efficiency  propeller "
+"that will produce\n"
+"the required thrust at the specified speed  of  advance. The  Burrill  5%  "
+"back  cavitation\n"
+"criterion is recommended. The program does  not  check  to  see  that  the "
+"resulting design\n"
+"is \"slightly to the left\" of the peak of the efficiency versus  J  "
+"diagram  as  is  usually\n"
+"recommended as margin if the  design  misses  the  predicted  operating "
+"point RPM. The user\n"
+"should check this on the graphical output.\n"
+"1.5 An error message will be  printed if the determination of the RPM needed "
+"to produce the\n"
+"required thrust does not converge within 400 iterations within the "
+"computations.\n"
+"1.6 Propeller Type allows the selection of a fixed-pitch or controllable-"
+"pitch propeller.\n"
+"At this time, only the Wageningen B-Screw Series is supported and the open "
+"water efficiency\n"
+"is reduced by 2 percent  for  the controllable-pitch propeller option to "
+"reflect the larger\n"
+"hub.\n"
+"1.7 Propeller Characteristics  obtains  the  blade  number and the basic "
+"parameters for the\n"
+"propeller. If the optimization option is being used, the parameters are the "
+"initial  values\n"
+"used by the search algorithm. If the evaluation option is  being used, the  "
+"parameters  are\n"
+"those evaluated by the program.\n"
+"1.7.1 Nblade number of blades on propeller, 3 through 7 supported.\n"
+"1.7.2 Ae/Ao initial point for search or evaluated expanded area ratio.\n"
+"1.7.3 P/Dp initial point for search or evaluated pitch diameter ratio.\n"
+"1.7.4 Dp initial point for search or evaluated propeller diameter in "
+"meters.\n"
+"1.8 Operating  Conditions  obtains the ship speed, wake fraction, and thrust "
+"required from\n"
+"the propeller. It also allows  the  selection  of  the  5%  or  10% Burrill "
+"back cavitation\n"
+"constraint and obtains  the  submergence  of  the  shaft centerline needed "
+"to calculate the\n"
+"Cavitation Number at the blade tip.\n"
+"1.8.1 THR required thrust per propeller in kilonewtons, THR = Rt/Zp/(1 - "
+"t);\n"
+"1.8.2 Vk - ship speed in knots;\n"
+"1.8.3 w - average longitudinal wake fraction;\n"
+"1.8.4 HWLM - depth of shaft centerline below waterline in meters.\n"
+"1.9 Water Properties allows the choice of fresh water @ 15C, salt water @ "
+"15C or user-spe-\n"
+"cified water properties.\n"
+"1.10 When the optimization is selected, a minimum and maximum propeller  "
+"diameter  must  be\n"
+"specified. The user can also enter a run specific identifier at this point, "
+"if desired.\n"
+"1.10.1 Dpmin - Minimum propeller diameter in meters. Typically this is about "
+"25% of Dpmax for\n"
+"fixed-pitch propellers and about 35% of Dpmax for controllable-pitch "
+"propellers.\n"
+"1.10.2 Dpmax - Maximum propeller diameter permitted by hull and required "
+"clearances,in meters.\n"
+"1.11 When the analysis process is completed, the program can be produce an "
+"open water efficiency,\n"
+"KT, and KQ versus J and plot graphics.\n"
+"REFERENCES:\n"
+"1.Oosterveld, M. W. C., and  van Oossanen, P. , \" Further  Computer-"
+"Analyzed  Data  of  the\n"
+"Wageningen B-Screw Series,\" International Shipbuilding Progress, Vol.22, "
+"No.251, July,1975.\n"
+"2.Parsons, M. G., \"Optimization Methods for Use in Computer-Aided Ship "
+"Design,\" Proceedings\n"
+"of the First SNAME STAR Symposium, 1975.\n"
+"3.Comstock,J.P. (Ed.), Principles of Naval Architecture, Vol. II, 1988  "
+"Edition, SNAME, New\n"
+"York, p.182."
+msgstr ""
+
+#: freestringsunit.rs_hydronship_addedmass_note
+msgid ""
+"HydroNShIp_AddedMass v1.03 is free  CFD  software of added masses "
+"calculation for\n"
+"education and noncommercial use only.\n"
+"Copyright (c) 1987-1994 Dudchenko O.M., 1992-2009 Timoshenko V.F.\n"
+"1.METHODS:\n"
+"1.1   Added masses are defined numerically by a method of successive  "
+"approxima-\n"
+"tions at the decision of integrated equations Fredholm of 2-nd  sort  "
+"concerning\n"
+"density of hydrodynamic features (sources - effluents) distributing "
+"continuously\n"
+"on surface ship hull (with keels) with  the  account  and  without  taking  "
+"into\n"
+"account effect of a bottom and a trim [1,2]. Thus we believe,that a fluid "
+"ideal,\n"
+"incompressible, and movement potential. Ship hull is  considered  as  the  "
+"solid\n"
+"limited to the closed surface and moving in a boundless fluid.\n"
+"2.LIMITATIONS of freeware version:\n"
+"2.1 Interaction between catamarans  hulls  in  freeware HydroNShIp_AddedMass "
+"not\n"
+"calculate.\n"
+"2.2 User must be control input data for water depth value and trim "
+"angle,because\n"
+"intersection between a ship hull surface and sea bottom is not admiss.\n"
+"2.3 This  is  limited  number  of  areas (not  more 1600)for modeling "
+"surface of\n"
+"a ship hull. It's decrease accuracy of added masses calculation.\n"
+"\n"
+"3.REFERENCES:\n"
+"1. Dudchenko O.N. Numerical calculation inertia characteristics of a body in "
+"in-\n"
+"finite fluid//Ship hydrodynamics: Sb.nauch.tr. - Nikolaev, NKI,1987.- "
+"p.21-26.\n"
+"2. Timoshenko V.F. Investigation of submercible vechicle inertia "
+"characteristics\n"
+"near bottom and in stratified fluid//Ship hydrodynamics: Sb.nauch.tr.- "
+"Nikolaev,\n"
+"NKI, 1993. - p. 22-27.\n"
+"3. Korotkin A.I. Prisoedinennie massy sudna: Spravochnik.-"
+"L.:Sudostroenie,1986,312pp.\n"
+"4. Hofman A.D. Dvigitelno-rulevoy kompleks i manevrirovanie sudna: "
+"Spravochnik. -\n"
+"L.:Sudostroenie,1988,360pp."
+msgstr ""
+
+#: freestringsunit.rs_hydrostatics_calculation_is_not_possible__because_there_is_leak_point_under_dwl___
+msgid ""
+"Hydrostatics calculation is not possible, because there is leak point under "
+"DWL!!!"
+msgstr ""
+
+#: freestringsunit.rs_if_sigmab_4___1____
+msgid "If SigmaB/4 > 1 ==>"
+msgstr ""
+
+#: freestringsunit.rs_if_sigmab___1____
+msgid "If SigmaB > 1 ==>"
+msgstr ""
+
+#: freestringsunit.rs_impeller_type_
+msgid "Impeller Type:"
+msgstr ""
+
+#: freestringsunit.rs_import_bodyplan
+msgid "import bodyplan"
+msgstr ""
+
+#: freestringsunit.rs_import_carene_file
+msgid "import carene file"
+msgstr ""
+
+#: freestringsunit.rs_import_chines
+msgid "import chines"
+msgstr ""
+
+#: freestringsunit.rs_import_markers
+msgid "import markers"
+msgstr ""
+
+#: freestringsunit.rs_import_obj_file
+msgid "import OBJ file"
+msgstr ""
+
+#: freestringsunit.rs_import_part
+msgid "Import part"
+msgstr ""
+
+#: freestringsunit.rs_import_polycad_file
+msgid "import PolyCad file"
+msgstr ""
+
+#: freestringsunit.rs_import_stl_file
+msgid "import STL file"
+msgstr ""
+
+#: freestringsunit.rs_import_surface
+msgid "import surface"
+msgstr ""
+
+#: freestringsunit.rs_import_vrml_file
+msgid "import VRML file"
+msgstr ""
+
+#: freestringsunit.rs_import__fef_file
+msgid "import .Fef file"
+msgstr ""
+
+#: freestringsunit.rs_import__hul_file
+msgid "import .hul file"
+msgstr ""
+
+#: freestringsunit.rs_in
+msgid "in"
+msgstr ""
+
+#: freestringsunit.rs_inches
+msgid "Inches"
+msgstr ""
+
+#: freestringsunit.rs_inconsistent_normals
+msgid "inconsistent normals"
+msgstr ""
+
+#: freestringsunit.rs_incr__distance
+msgid "Incr. distance"
+msgstr ""
+
+#: freestringsunit.rs_initial_expanded_area_ratio_ae_ao______
+msgid "Initial Expanded Area Ratio Ae/Ao     ="
+msgstr ""
+
+#: freestringsunit.rs_initial_longitudinal_metacentric_height_ho
+msgid "Initial longitudinal metacentric height Ho"
+msgstr ""
+
+#: freestringsunit.rs_initial_pitch_diameter_ratio_p_dp______
+msgid "Initial Pitch Diameter Ratio P/Dp     ="
+msgstr ""
+
+#: freestringsunit.rs_initial_propeller_diameter_dp__m_______
+msgid "Initial Propeller Diameter Dp (m)     ="
+msgstr ""
+
+#: freestringsunit.rs_initial_stability
+msgid "Initial stability"
+msgstr ""
+
+#: freestringsunit.rs_initial_transverse_metacentric_height_ho
+msgid "Initial transverse metacentric height ho"
+msgstr ""
+
+#: freestringsunit.rs_input_variables
+msgid "Input variables"
+msgstr ""
+
+#: freestringsunit.rs_input_verification_
+msgid "Input Verification:"
+msgstr ""
+
+#: freestringsunit.rs_insert_plane_intersections
+msgid "insert plane intersections"
+msgstr ""
+
+#: freestringsunit.rs_institution_of_naval_architects__1973_
+msgid "Institution of Naval Architects, 1973."
+msgstr ""
+
+#: freestringsunit.rs_invalid_contour_distance_
+msgid "Invalid contour distance."
+msgstr ""
+
+#: freestringsunit.rs_invalid_coordinate
+msgid "Invalid coordinate"
+msgstr ""
+
+#: freestringsunit.rs_invalid_displacement
+msgid "Invalid displacement"
+msgstr ""
+
+#: freestringsunit.rs_invalid_floating_point_value_in_surface
+msgid "Invalid floating point value in surface"
+msgstr ""
+
+#: freestringsunit.rs_invalid_integer_value_in_surface
+msgid "Invalid integer value in surface"
+msgstr ""
+
+#: freestringsunit.rs_invalid_unit_identifier_
+msgid "Invalid unit identifier!"
+msgstr ""
+
+#: freestringsunit.rs_invalid_value
+msgid "Invalid value"
+msgstr ""
+
+#: freestringsunit.rs_invalid_wave_pattern_file_
+msgid "Invalid wave pattern file!"
+msgstr ""
+
+#: freestringsunit.rs_invalid_x_coordinate_in_surface
+msgid "Invalid x-coordinate in surface"
+msgstr ""
+
+#: freestringsunit.rs_invalid_y_coordinate_in_surface
+msgid "Invalid y-coordinate in surface"
+msgstr ""
+
+#: freestringsunit.rs_invalid_z_coordinate_in_surface
+msgid "Invalid z-coordinate in surface"
+msgstr ""
+
+#: freestringsunit.rs_is_lower_then_critical__increase_engine_power_
+msgid "is lower then critical. Increase engine power."
+msgstr ""
+
+#: freestringsunit.rs_is_no_valid_numeric_input
+msgid "is no valid numeric input"
+msgstr ""
+
+#: freestringsunit.rs_is_outside_valid_domain
+msgid "is outside valid domain"
+msgstr ""
+
+#: freestringsunit.rs_iterations
+msgid "iterations"
+msgstr ""
+
+#: freestringsunit.rs_ixx__iyy__izz_____
+msgid "Ixx, Iyy, Izz    ="
+msgstr ""
+
+#: freestringsunit.rs_j________kt_____dkt____kttdkt_______kq______dkq____kqtdkq_____eta_0
+msgid "J        KT     DKT    KT+DKT       KQ      DKQ    KQ+DKQ     ETA-0"
+msgstr ""
+
+#: freestringsunit.rs_k11__k22__k33_____
+msgid "k11, k22, k33    ="
+msgstr ""
+
+#: freestringsunit.rs_k44__k55__k66_____
+msgid "k44, k55, k66    ="
+msgstr ""
+
+#: freestringsunit.rs_kaper_resistance_for_canoes_and_kayaks
+msgid "KAPER resistance for canoes and kayaks"
+msgstr ""
+
+#: freestringsunit.rs_keel
+msgctxt "freestringsunit.rs_keel"
+msgid "Keel"
+msgstr "Quilha"
+
+#: freestringsunit.rs_keel_s_properties
+msgid "Keel's properties"
+msgstr ""
+
+#: freestringsunit.rs_kg
+msgid "kg"
+msgstr ""
+
+#: freestringsunit.rs_kg_ft_3
+msgid "kg/ft^3"
+msgstr ""
+
+#: freestringsunit.rs_kg_m_3
+msgid "kg/m^3"
+msgstr ""
+
+#: freestringsunit.rs_kinematic_viscosity_nu__m_2_sec________
+msgid "Kinematic Viscosity Nu (m^2/sec)      ="
+msgstr ""
+
+#: freestringsunit.rs_kinematic_viscosity__m_2_s______________
+msgid "Kinematic Viscosity (m^2/s)            ="
+msgstr ""
+
+#: freestringsunit.rs_km_hour
+msgid "km/hour"
+msgstr ""
+
+#: freestringsunit.rs_kn
+msgid "kN"
+msgstr ""
+
+#: freestringsunit.rs_knom
+msgid "kN*m"
+msgstr ""
+
+#: freestringsunit.rs_knots
+msgid "knots"
+msgstr ""
+
+#: freestringsunit.rs_kn_sin_psi_
+msgid "KN sin(Psi)"
+msgstr ""
+
+#: freestringsunit.rs_kw
+msgid "kW"
+msgstr ""
+
+#: freestringsunit.rs_l10_l_wdz____l_m3__l
+msgid "|10 | Wdz    |[m3] |"
+msgstr ""
+
+#: freestringsunit.rs_l11_l_g______l_kg__l
+msgid "|11 | G      |[kg] |"
+msgstr ""
+
+#: freestringsunit.rs_l12_l_pc_____l_kn__l
+msgid "|12 | Pc     |[kN] |"
+msgstr ""
+
+#: freestringsunit.rs_l13_l_mc_____lknom_l
+msgid "|13 | Mc     |kN*m |"
+msgstr ""
+
+#: freestringsunit.rs_l14_l_sigma__ln_mm2l
+msgid "|14 | Sigma  |N/mm2|"
+msgstr ""
+
+#: freestringsunit.rs_l15_l_sigmac_ln_mm2l
+msgid "|15 | SigmaC |N/mm2|"
+msgstr ""
+
+#: freestringsunit.rs_l16_l_sigmas_ln_mm2l
+msgid "|16 | SigmaS |N/mm2|"
+msgstr ""
+
+#: freestringsunit.rs_l17_l_sigmab_l_____l
+msgid "|17 | SigmaB |  -  |"
+msgstr ""
+
+#: freestringsunit.rs_l18_lsigmab_4l_____l
+msgid "|18 |SigmaB/4|  -  |"
+msgstr ""
+
+#: freestringsunit.rs_lackenby_tranformation
+msgid "Lackenby tranformation"
+msgstr ""
+
+#: freestringsunit.rs_last_state
+msgid "Last state"
+msgstr ""
+
+#: freestringsunit.rs_lateral_area
+msgid "Lateral area"
+msgstr ""
+
+#: freestringsunit.rs_lateral_force__kn_
+msgid "Lateral force [kN]"
+msgstr ""
+
+#: freestringsunit.rs_lateral_plane
+msgid "Lateral plane"
+msgstr ""
+
+#: freestringsunit.rs_lateral_projected_wind_area__________al__
+msgid "LATERAL PROJECTED WIND AREA ........ AL :"
+msgstr ""
+
+#: freestringsunit.rs_lateral_proj__area_of_superstructure_as__
+msgid "LATERAL PROJ. AREA OF SUPERSTRUCTURE AS :"
+msgstr ""
+
+#: freestringsunit.rs_lateral_wind_area
+msgid "Lateral wind area"
+msgstr ""
+
+#: freestringsunit.rs_layer
+msgctxt "freestringsunit.rs_layer"
+msgid "Layer"
+msgstr ""
+
+#: freestringsunit.rs_layer_grouping
+msgid "layer grouping"
+msgstr ""
+
+#: freestringsunit.rs_layer_intersection
+msgid "layer intersection"
+msgstr ""
+
+#: freestringsunit.rs_layer_properties
+msgid "layer properties"
+msgstr ""
+
+#: freestringsunit.rs_lbs
+msgid "lbs"
+msgstr ""
+
+#: freestringsunit.rs_lbs_ft_3
+msgid "lbs/ft^3"
+msgstr ""
+
+#: freestringsunit.rs_lcb
+msgctxt "freestringsunit.rs_lcb"
+msgid "LCB"
+msgstr ""
+
+#: freestringsunit.rs_lcb_is_outside_valid_domain
+msgid "LCB is outside valid domain"
+msgstr ""
+
+#: freestringsunit.rs_lcb_lpp
+msgid "LCB/Lpp"
+msgstr ""
+
+#: freestringsunit.rs_leak_points
+msgid "leak points"
+msgstr ""
+
+#: freestringsunit.rs_length
+msgctxt "freestringsunit.rs_length"
+msgid "Length"
+msgstr "Comprimento"
+
+#: freestringsunit.rs_length_of_cylindrical_body__m
+msgid "Length of cylindrical body, m"
+msgstr "Comprimento do corpo cilíndrico, m"
+
+#: freestringsunit.rs_length_of_perimeter___________________s__
+msgid "LENGTH OF PERIMETER ................. S :"
+msgstr ""
+
+#: freestringsunit.rs_length_of_waterline_lwl__m______________
+msgid "Length of Waterline LWL (m)            ="
+msgstr "Comprimento na Linha D'água LWL (m)      ="
+
+#: freestringsunit.rs_length_on_waterline
+msgid "Length on waterline"
+msgstr "Comprimento na linha d'água"
+
+#: freestringsunit.rs_length_overall_____________________sloa__
+msgid "LENGTH OVERALL ................... SLOA :"
+msgstr ""
+
+#: freestringsunit.rs_length_over_all
+msgid "Length over all"
+msgstr "Comprimento total"
+
+#: freestringsunit.rs_length_over_surface_los
+msgid "Length over surface Los"
+msgstr "Comprimento sobre a superfície Los"
+
+#: freestringsunit.rs_limit_diameter_of_propeller__m_
+msgid "Limit diameter of propeller [m]"
+msgstr ""
+
+#: freestringsunit.rs_limit_of_power_in_freeware_free_shipt_is_reached_or_increase_diameter_of_propeller___
+msgid ""
+"Limit of power in freeware Free!ship+ is reached or increase diameter of "
+"propeller!!!"
+msgstr ""
+
+#: freestringsunit.rs_limit_of_speed_in_freeware_free_shipt_is_reached___
+msgid "Limit of speed in freeware Free!ship+ is reached!!!"
+msgstr ""
+
+#: freestringsunit.rs_lnumlcharact_lmeas_l________________________m_e_a_n_i_n_g_s________________________l
+msgid ""
+"|Num|Charact.|Meas.|                        M E A N I N G "
+"S                        |"
+msgstr ""
+
+#: freestringsunit.rs_location
+msgid "Location"
+msgstr ""
+
+#: freestringsunit.rs_locked_points_can_not_be_moved_
+msgid "Locked points can not be moved!"
+msgstr ""
+
+#: freestringsunit.rs_lock_points
+msgid "lock points"
+msgstr ""
+
+#: freestringsunit.rs_longitudinal_center_of_buoyancy
+msgid "Longitudinal center of buoyancy"
+msgstr ""
+
+#: freestringsunit.rs_longitudinal_center_of_effort
+msgid "Longitudinal center of effort"
+msgstr ""
+
+#: freestringsunit.rs_longitudinal_derivational_moment
+msgid "Longitudinal derivational moment"
+msgstr ""
+
+#: freestringsunit.rs_longitudinal_metacentric_radius
+msgid "Longitudinal metacentric radius"
+msgstr ""
+
+#: freestringsunit.rs_longitudinal_moment_of_inertia
+msgid "Longitudinal moment of inertia"
+msgstr ""
+
+#: freestringsunit.rs_longitudinal_transverse_metacenter
+msgid "Longitudinal transverse metacenter"
+msgstr ""
+
+#: freestringsunit.rs_lpropeller_s_metal_l___1___l___2___l___3___l___4___l___5___l___6___l___7___l___8___l
+msgid ""
+"|Propeller's metal:|   1   |   2   |   3   |   4   |   5   |   6   |   7   "
+"|   8   |"
+msgstr ""
+
+#: freestringsunit.rs_lwl_bwl_is_outside_valid_domain
+msgid "Lwl/Bwl is outside valid domain"
+msgstr ""
+
+#: freestringsunit.rs_lwl_v_3_is_outside_valid_domain
+msgid "Lwl/V^3 is outside valid domain"
+msgstr ""
+
+#: freestringsunit.rs_l_1_l_bmax___l__m__l
+msgid "| 1 | Bmax   | [m] |"
+msgstr ""
+
+#: freestringsunit.rs_l_2_l_bl_____l__m__l
+msgid "| 2 | Bl     | [m] |"
+msgstr ""
+
+#: freestringsunit.rs_l_3_l_e______l__m__l
+msgid "| 3 | e      | [m] |"
+msgstr ""
+
+#: freestringsunit.rs_l_4_l_fi_____l_degrl
+msgid "| 4 | fi     | degr|"
+msgstr ""
+
+#: freestringsunit.rs_l_5_l_gp_____l_____l
+msgid "| 5 | Gp     |  -  |"
+msgstr ""
+
+#: freestringsunit.rs_l_6_l_gt_____l_____l
+msgid "| 6 | Gt     |  -  |"
+msgstr ""
+
+#: freestringsunit.rs_l_7_l_mp_____lknom_l
+msgid "| 7 | Mp     |kN*m |"
+msgstr ""
+
+#: freestringsunit.rs_l_8_l_mt_____lknom_l
+msgid "| 8 | Mt     |kN*m |"
+msgstr ""
+
+#: freestringsunit.rs_l_9_l_f______l_m2__l
+msgid "| 9 | F      |[m2] |"
+msgstr ""
+
+#: freestringsunit.rs_l_character___l___________________t____________________t__twin_screw_ship__l
+msgid ""
+"| Character.  |-------------------+--------------------+  Twin-screw ship  |"
+msgstr ""
+
+#: freestringsunit.rs_l_d________l___m____l
+msgid "| D        |  [m]   |"
+msgstr ""
+
+#: freestringsunit.rs_l_eta0_____l________l
+msgid "| Eta0     |  [-]   |"
+msgstr ""
+
+#: freestringsunit.rs_l_etad_____l________l
+msgid "| EtaD     |  [-]   |"
+msgstr ""
+
+#: freestringsunit.rs_l_jopt_____l________l
+msgid "| Jopt     |  [-]   |"
+msgstr ""
+
+#: freestringsunit.rs_l_j________l________l
+msgid "| J        |  [-]   |"
+msgstr ""
+
+#: freestringsunit.rs_l_kdt______l________l
+msgid "| Kdt      |  [-]   |"
+msgstr ""
+
+#: freestringsunit.rs_l_knt______l________l
+msgid "| Knt      |  [-]   |"
+msgstr ""
+
+#: freestringsunit.rs_l_kt_______l________l
+msgid "| Kt       |  [-]   |"
+msgstr ""
+
+#: freestringsunit.rs_l_l_voo0_3333_l__4_490_____6_008__l__5_450_____7_047___l__4_405_____7_265__l
+msgid ""
+"| L/V**0.3333 |  4.490 ... 6.008  |  5.450 ... 7.047   |  4.405 ... 7.265  |"
+msgstr ""
+
+#: freestringsunit.rs_l_n________l_1_min__l
+msgid "| n        |[1/min] |"
+msgstr ""
+
+#: freestringsunit.rs_l_pe_______l___kw___l
+msgid "| Pe       |  [kW]  |"
+msgstr ""
+
+#: freestringsunit.rs_l_ps_n_____l___kw___l
+msgid "| Ps_n     |  [kW]  |"
+msgstr ""
+
+#: freestringsunit.rs_l_ps_r_____l___kw___l
+msgid "| Ps_r     |  [kW]  |"
+msgstr ""
+
+#: freestringsunit.rs_l_ps_______l___kw___l
+msgid "| Ps       |  [kW]  |"
+msgstr ""
+
+#: freestringsunit.rs_l_p_d______l________l
+msgid "| P/D      |  [-]   |"
+msgstr ""
+
+#: freestringsunit.rs_l_r________l___kn___l
+msgid "| R        |  [kN]  |"
+msgstr ""
+
+#: freestringsunit.rs_l_speed_l_speed_l_fr_v__l___r_f__l___r_r__l___r_t__l__power__l__r_t_e_l_power_e_l
+msgid ""
+"| Speed | Speed | Fr_V  |   R_f  |   R_r  |   R_T  |  Power  |  R_T_e | "
+"Power_e |"
+msgstr ""
+
+#: freestringsunit.rs_l_speed_l_speed_l__fr___l___r_f__l___r_r__l___r_t__l__power__l__r_t_e_l_power_e_l
+msgid ""
+"| Speed | Speed |  Fr   |   R_f  |   R_r  |   R_T  |  Power  |  R_T_e | "
+"Power_e |"
+msgstr ""
+
+#: freestringsunit.rs_l_speed_l_speed_l__fr___l___r_f__l___r_r__l___r_t__l__power__l___wt__l___t___l
+msgid ""
+"| Speed | Speed |  Fr   |   R_f  |   R_r  |   R_T  |  Power  |   Wt  |   t   "
+"|"
+msgstr ""
+
+#: freestringsunit.rs_l_speed_l_speed_l__fr___l___r_f___l___r_r___l____r_t____l__power__l_cp_opt__l_lcb_opt_l
+msgid ""
+"| Speed | Speed |  Fr   |   R_f   |   R_r   |    R_T    |  Power  | Cp opt. "
+"| LCB opt |"
+msgstr ""
+
+#: freestringsunit.rs_l_speed_l_speed_l__fr___l___r_v__l___r_r__l___r_t__l__power__l__r_t_e_l_power_e_l
+msgid ""
+"| Speed | Speed |  Fr   |   R_v  |   R_r  |   R_T  |  Power  |  R_T_e | "
+"Power_e |"
+msgstr ""
+
+#: freestringsunit.rs_l_speed_l_speed_l__s_l__l_r_frict_l_r_resid_l_r_total_l_spilman_l
+msgid "| Speed | Speed |  S/L  | R frict.| R resid.| R total | Spilman |"
+msgstr ""
+
+#: freestringsunit.rs_l_tb_______l___kn___l
+msgid "| Tb       |  [kN]  |"
+msgstr ""
+
+#: freestringsunit.rs_l_va_______l___m_s__l
+msgid "| Va       |  [m/s] |"
+msgstr ""
+
+#: freestringsunit.rs_l_vs_______l___kn___l
+msgid "| Vs       |  [kn]  |"
+msgstr ""
+
+#: freestringsunit.rs_l__b__t___m_______
+msgid "L, B, T , m      ="
+msgstr ""
+
+#: freestringsunit.rs_l__value___lmeasureml______________m_e_a_n_i_n_g_s_______________l
+msgid "|  Value   |Measurem|              M e a n i n g s               |"
+msgstr ""
+
+#: freestringsunit.rs_l__value___lmeasureml_______________m_e_a_n_i_n_g_s______________l
+msgid "|  Value   |Measurem|               M E A N I N G S              |"
+msgstr ""
+
+#: freestringsunit.rs_l___kn__l__ft_s_l_ratio_l___lbs___l___lbs___l___lbs___l___lbs___l
+msgid "|  [kn] | [ft/s]| ratio |  [lbs]  |  [lbs]  |  [lbs]  |  [lbs]  |"
+msgstr ""
+
+#: freestringsunit.rs_l___kn__l__m_s__l_ratio_l____n____l____n____l____n____l____n____l
+msgid "|  [kn] | [m/s] | ratio |   [N]   |   [N]   |   [N]   |   [N]   |"
+msgstr ""
+
+#: freestringsunit.rs_l___kn__l__m_s__l_______l___kn___l___kn___l____kn__l____kw___l____kn__l____kw___l
+msgid ""
+"|  [kn] | [m/s] |  [-]  |  [kN]  |  [kN]  |   [kN] |   [kW]  |   [kN] |   "
+"[kW]  |"
+msgstr ""
+
+#: freestringsunit.rs_l___kn__l__m_s__l_______l___kn___l___kn___l____kn__l____kw___l_______l_______l
+msgid ""
+"|  [kn] | [m/s] |  [-]  |  [kN]  |  [kN]  |   [kN] |   [kW]  |  [-]  |  [-]  "
+"|"
+msgstr ""
+
+#: freestringsunit.rs_l___kn__l__m_s__l_______l___kn____l___kn____l____kn_____l____kw___l_________l_________l
+msgid ""
+"|  [kn] | [m/s] |  [-]  |  [kN]   |  [kN]   |   [kN]    |   [kW]  |   [-]   "
+"|   [%]   |"
+msgstr ""
+
+#: freestringsunit.rs_l___kn__l__m_s__l_______l____n___l____n___l____n___l____w____l____n___l____w____l
+msgid ""
+"|  [kn] | [m/s] |  [-]  |   [N]  |   [N]  |   [N]  |   [W]   |   [N]  |   "
+"[W]   |"
+msgstr ""
+
+#: freestringsunit.rs_l___kn__l__m_s__l_______l____n___l____n___l____n___l____w____l_______l_______l
+msgid ""
+"|  [kn] | [m/s] |  [-]  |   [N]  |   [N]  |   [N]  |   [W]   |  [-]  |  [-]  "
+"|"
+msgstr ""
+
+#: freestringsunit.rs_l___kn__l__m_s__l_______l____n____l____n____l_____n_____l____w____l_________l_________l
+msgid ""
+"|  [kn] | [m/s] |  [-]  |   [N]   |   [N]   |    [N]    |   [W]   |   [-]   "
+"|   [%]   |"
+msgstr ""
+
+#: freestringsunit.rs_l___kn__l_______l__degr_l___kn____l___kn____l___kn____l___kw____l
+msgid "|  [kn] |   -   | [degr]|  [kN]   |  [kN]   |  [kN]   |  [kW]   |"
+msgstr ""
+
+#: freestringsunit.rs_l___kn__l_______l__degr_l___lbf___l___lbf___l___lbf___l___ehp___l
+msgid "|  [kn] |   -   | [degr]|  [lbf]  |  [lbf]  |  [lbf]  |  [ehp]  |"
+msgstr ""
+
+#: freestringsunit.rs_l___kn__l_______l_______l___kn____l___kn____l___kn____l___kw____l
+msgid "|  [kn] |   -   |   -   |  [kN]   |  [kN]   |  [kN]   |  [kW]   |"
+msgstr ""
+
+#: freestringsunit.rs_l___kn__l_______l_______l___kn____l____kn___l____kn___l___kw____l
+msgid "|  [kn] |   -   |   -   |  [kN]   |   [kN]  |   [kN]  |  [kW]   |"
+msgstr ""
+
+#: freestringsunit.rs_l___kn__l_______l_______l___lbf___l___lbf___l___lbf___l___ehp___l
+msgid "|  [kn] |   -   |   -   |  [lbf]  |  [lbf]  |  [lbf]  |  [ehp]  |"
+msgstr ""
+
+#: freestringsunit.rs_l___kn___l___m_s__l________l___kn___l___kn___l___kn___l___kw___l___kn___l___kw___l
+msgid ""
+"|   kn   |   m/s  |    -   |   kN   |   kN   |   kN   |   kW   |   kN   |   "
+"kW   |"
+msgstr ""
+
+#: freestringsunit.rs_l___kn___l___m_s__l________l____n___l____n___l____n___l___w____l____n___l___w____l
+msgid ""
+"|   kn   |   m/s  |    -   |    N   |    N   |    N   |   W    |    N   |   "
+"W    |"
+msgstr ""
+
+#: freestringsunit.rs_l___los_lwl___l__1_000_____1_050__l__1_000_____1_050___l__1_000_____1_050__l
+msgid ""
+"|   Los/Lwl   |  1.000 ... 1.050  |  1.000 ... 1.050   |  1.000 ... 1.050  |"
+msgstr ""
+
+#: freestringsunit.rs_l___lwl_l_____l__1_000_____1_055__l__0_945_____1_000___l__1_000_____1_070__l
+msgid ""
+"|   Lwl/L     |  1.000 ... 1.055  |  0.945 ... 1.000   |  1.000 ... 1.070  |"
+msgstr ""
+
+#: freestringsunit.rs_l___value__l______________m_e_a_n_i_n_g_s_______________l
+msgid "|   Value  |              M E A N I N G S               |"
+msgstr ""
+
+#: freestringsunit.rs_l___vs__l__frb__l__frv__l___r_f___l___r_r___l___r_t___l___pe____l
+msgid "|   Vs  |  FrB  |  FrV  |   R_f   |   R_r   |   R_t   |   Pe    |"
+msgstr ""
+
+#: freestringsunit.rs_l___vs__l__frb__l__tau__l___r_f___l___r_p___l___r_t___l___pe____l
+msgid "|   Vs  |  FrB  |  Tau  |   R_f   |   R_p   |   R_t   |   Pe    |"
+msgstr ""
+
+#: freestringsunit.rs_l___vs__l__frl__l__frv__l___r_f___l___r_r___l___r_t___l___pe____l
+msgid "|   Vs  |  FrL  |  FrV  |   R_f   |   R_r   |   R_t   |   Pe    |"
+msgstr ""
+
+#: freestringsunit.rs_l___vs__l__frv__lepsilonl___r_f___l___r_p___l___r_t___l___pe____l
+msgid "|   Vs  |  FrV  |Epsilon|   R_f   |   R_p   |   R_t   |   Pe    |"
+msgstr ""
+
+#: freestringsunit.rs_l___vs__l__frv__l__tau__l___r_f___l___r_p___l___r_t___l___pe____l
+msgid "|   Vs  |  FrV  |  Tau  |   R_f   |   R_p   |   R_t   |   Pe    |"
+msgstr ""
+
+#: freestringsunit.rs_l___vs___l___vms__l___fr___l___r_f__l___r_r__l___r_t__l___pe___l__r_t_e_l__pe_e__l
+msgid ""
+"|   Vs   |   Vms  |   Fr   |   R_f  |   R_r  |   R_T  |   Pe   |  R_T_e |  "
+"Pe_e  |"
+msgstr ""
+
+#: freestringsunit.rs_l____dp_ta____l__0_430_____0_840__l__0_655_____1_050___l__0_495_____0_860__l
+msgid ""
+"|    Dp/Ta    |  0.430 ... 0.840  |  0.655 ... 1.050   |  0.495 ... 0.860  |"
+msgstr ""
+
+#: freestringsunit.rs_l____jb____l________l
+msgid "|    Jb    |   -    |"
+msgstr ""
+
+#: freestringsunit.rs_l____jv____l
+msgid "|    Jv    |"
+msgstr ""
+
+#: freestringsunit.rs_l____j_____l
+msgid "|    J     |"
+msgstr ""
+
+#: freestringsunit.rs_l____kqb___l
+msgid "|    Kqb   |"
+msgstr ""
+
+#: freestringsunit.rs_l____kq____l
+msgid "|    Kq    |"
+msgstr ""
+
+#: freestringsunit.rs_l____ktb___l
+msgid "|    Ktb   |"
+msgstr ""
+
+#: freestringsunit.rs_l____kt____l
+msgid "|    Kt    |"
+msgstr ""
+
+#: freestringsunit.rs_l____n_____l__1_min_l
+msgid "|    n     | [1/min]|"
+msgstr ""
+
+#: freestringsunit.rs_l____parameter____l___calculated_l___optimal___l
+msgid "|    Parameter    |   Calculated |   Optimal   |"
+msgstr ""
+
+#: freestringsunit.rs_l____pd____l____kw__l
+msgid "|    Pd    |   [kW] |"
+msgstr ""
+
+#: freestringsunit.rs_l____ps____l___kw___l
+msgid "|    Ps    |  [kW]  |"
+msgstr ""
+
+#: freestringsunit.rs_l____s_____l
+msgid "|    s     |"
+msgstr ""
+
+#: freestringsunit.rs_l____te____l____kn__l
+msgid "|    Te    |   [kN] |"
+msgstr ""
+
+#: freestringsunit.rs_l____t_____l
+msgid "|    t     |"
+msgstr ""
+
+#: freestringsunit.rs_l____vs____l____kn__l
+msgid "|    vs    |   [kn] |"
+msgstr ""
+
+#: freestringsunit.rs_l_____b_t_____l__1_989_____4_002__l__2_967_____6_120___l__2_308_____6_110__l
+msgid ""
+"|     B/T     |  1.989 ... 4.002  |  2.967 ... 6.120   |  2.308 ... 6.110  |"
+msgstr ""
+
+#: freestringsunit.rs_l_____cb______l__0_601_____0_830__l__0_559_____0_790___l__0_512_____0_775__l
+msgid ""
+"|     Cb      |  0.601 ... 0.830  |  0.559 ... 0.790   |  0.512 ... 0.775  |"
+msgstr ""
+
+#: freestringsunit.rs_l_____l_b_____l__4_710_____7_106__l__4_949_____6_623___l__3_960_____7_130__l
+msgid ""
+"|     L/B     |  4.710 ... 7.106  |  4.949 ... 6.623   |  3.960 ... 7.130  |"
+msgstr ""
+
+#: freestringsunit.rs_l_____________l____design_draft___l___ballast_draft____l___________________l
+msgid ""
+"|             |    Design draft   |   Ballast draft    |                   |"
+msgstr ""
+
+#: freestringsunit.rs_l_____________l____________single_screw_ship___________l___________________l
+msgid ""
+"|             |            Single-screw ship           |                   |"
+msgstr ""
+
+#: freestringsunit.rs_m
+msgctxt "freestringsunit.rs_m"
+msgid "m"
+msgstr ""
+
+#: freestringsunit.rs_marine_technology__okt__1986
+msgid "Marine Technology, Okt. 1986"
+msgstr ""
+
+#: freestringsunit.rs_marker_has_no_owner_
+msgid "Marker has no owner!"
+msgstr ""
+
+#: freestringsunit.rs_maximal_gz
+msgid "Maximal GZ"
+msgstr ""
+
+#: freestringsunit.rs_maximal_heeling_moment
+msgid "Maximal heeling moment"
+msgstr ""
+
+#: freestringsunit.rs_maximal_speed
+msgctxt "freestringsunit.rs_maximal_speed"
+msgid "Maximal speed"
+msgstr ""
+
+#: freestringsunit.rs_maximal_wind_moment
+msgid "Maximal wind moment"
+msgstr ""
+
+#: freestringsunit.rs_maximum_beam_on_lwl__m__________________
+msgid "Maximum Beam on LWL (m)                ="
+msgstr ""
+
+#: freestringsunit.rs_maximum_diameter_constraint_dpmax__m___
+msgid "Maximum Diameter Constraint Dpmax (m) ="
+msgstr ""
+
+#: freestringsunit.rs_maximum_dynamic_heeling_angle
+msgid "Maximum dynamic heeling angle"
+msgstr ""
+
+#: freestringsunit.rs_maximum_efficiency______eta0_max__
+msgid "Maximum efficiency      Eta0_max ="
+msgstr ""
+
+#: freestringsunit.rs_mean_draft__m___________________________
+msgid "Mean Draft (m)                         ="
+msgstr ""
+
+#: freestringsunit.rs_measured_from_the_aft_perpendicular_at_x_0_0
+msgid "measured from the aft perpendicular at X=0.0"
+msgstr ""
+
+#: freestringsunit.rs_measured_from_the_keel_line_of_the_hull
+msgid "measured from the keel line of the hull"
+msgstr ""
+
+#: freestringsunit.rs_merchant_ship
+msgid "Merchant ship"
+msgstr ""
+
+#: freestringsunit.rs_meters
+msgctxt "freestringsunit.rs_meters"
+msgid "Meters"
+msgstr ""
+
+#: freestringsunit.rs_method__nm_1___geers__nm_2___doubrovin_
+msgid "Method (Nm=1 - Geers; Nm=2 - Doubrovin)"
+msgstr ""
+
+#: freestringsunit.rs_michlet_export
+msgid "Michlet export"
+msgstr ""
+
+#: freestringsunit.rs_midship_area
+msgid "Midship area"
+msgstr ""
+
+#: freestringsunit.rs_midship_area_above_waterline
+msgid "Midship area above waterline"
+msgstr ""
+
+#: freestringsunit.rs_midship_coefficient
+msgid "Midship coefficient"
+msgstr ""
+
+#: freestringsunit.rs_midship_coefficient_to_lwl_______cm_cx__
+msgid "Midship Coefficient to LWL       CM=CX ="
+msgstr ""
+
+#: freestringsunit.rs_midship_draft
+msgctxt "freestringsunit.rs_midship_draft"
+msgid "Midship draft"
+msgstr ""
+
+#: freestringsunit.rs_midship_location
+msgid "Midship location"
+msgstr ""
+
+#: freestringsunit.rs_midship_properties
+msgid "Midship properties"
+msgstr ""
+
+#: freestringsunit.rs_midship_section_area
+msgid "Midship section area"
+msgstr ""
+
+#: freestringsunit.rs_millimeters
+msgid "Millimeters"
+msgstr ""
+
+#: freestringsunit.rs_min
+msgid "min"
+msgstr ""
+
+#: freestringsunit.rs_minimal_board_height_over_dwl
+msgid "Minimal board height over DWL"
+msgstr ""
+
+#: freestringsunit.rs_minimum_diameter_constraint_dpmin__m___
+msgid "Minimum Diameter Constraint Dpmin (m) ="
+msgstr ""
+
+#: freestringsunit.rs_mirror
+msgid "mirror"
+msgstr ""
+
+#: freestringsunit.rs_missing_file_in_exec__folder_
+msgid "Missing file in Exec/ folder:"
+msgstr ""
+
+#: freestringsunit.rs_mm
+msgid "mm"
+msgstr ""
+
+#: freestringsunit.rs_model_is_ok_
+msgid "Model is ok."
+msgstr ""
+
+#: freestringsunit.rs_modified
+msgid "modified"
+msgstr ""
+
+#: freestringsunit.rs_molded_volume__m_3______________________
+msgid "Molded Volume (m^3)                    ="
+msgstr ""
+
+#: freestringsunit.rs_morad
+msgid "m*rad"
+msgstr ""
+
+#: freestringsunit.rs_move
+msgid "move"
+msgstr ""
+
+#: freestringsunit.rs_m_2
+msgid "m^2"
+msgstr ""
+
+#: freestringsunit.rs_m_2_s
+msgctxt "freestringsunit.rs_m_2_s"
+msgid "m^2/s"
+msgstr ""
+
+#: freestringsunit.rs_m_3
+msgid "m^3"
+msgstr ""
+
+#: freestringsunit.rs_m_4
+msgid "m^4"
+msgstr ""
+
+#: freestringsunit.rs_m_s
+msgid "m/s"
+msgstr ""
+
+#: freestringsunit.rs_n
+msgid "N"
+msgstr ""
+
+#: freestringsunit.rs_need_enable_automoving_model_to_baseline_or_set_new_project_draft_
+msgid "Need enable automoving model to baseline or set new project draft."
+msgstr ""
+
+#: freestringsunit.rs_need_restart_calculation__design_hydrostatics__for_model_displacement_balance___
+msgid ""
+"Need restart calculation \"Design hydrostatics\" for model displacement "
+"balance..."
+msgstr ""
+
+#: freestringsunit.rs_new_controlcurve
+msgid "new controlcurve"
+msgstr ""
+
+#: freestringsunit.rs_new_coordinate
+msgid "New coordinate"
+msgstr ""
+
+#: freestringsunit.rs_new_edge
+msgid "new edge"
+msgstr ""
+
+#: freestringsunit.rs_new_face
+msgid "new face"
+msgstr ""
+
+#: freestringsunit.rs_new_increment_distance
+msgid "New increment distance"
+msgstr ""
+
+#: freestringsunit.rs_new_intersection
+msgid "New intersection"
+msgstr ""
+
+#: freestringsunit.rs_new_layer
+msgid "new layer"
+msgstr ""
+
+#: freestringsunit.rs_new_model
+msgid "new model"
+msgstr ""
+
+#: freestringsunit.rs_new_range_of_intersections
+msgid "New range of intersections"
+msgstr ""
+
+#: freestringsunit.rs_normals_flipped_to_point_outward
+msgid "normals flipped to point outward"
+msgstr ""
+
+#: freestringsunit.rs_note_1__calculated_number_of_hull_surface_areas___
+msgid "Note 1: Calculated number of hull surface areas  :"
+msgstr ""
+
+#: freestringsunit.rs_note_1__draft__and_all_other_vertical_heights__is_measured_from_point_of_the_hull_z_0_
+msgid ""
+"NOTE 1: Draft (and all other vertical heights) is measured from point of the "
+"hull Z=0."
+msgstr ""
+
+#: freestringsunit.rs_note_2__added_masses_are_be_devided_on____________
+msgid "Note 2: Added masses are be devided on           :"
+msgstr ""
+
+#: freestringsunit.rs_note_2__all_calculated_coefficients_based_on_actual_dimensions_of_submerged_body_
+msgid ""
+"NOTE 2: All calculated coefficients based on actual dimensions of submerged "
+"body."
+msgstr ""
+
+#: freestringsunit.rs_note_2__all_calculated_coefficients_based_on_project_length___draft_and_beam_
+msgid ""
+"NOTE 2: All calculated coefficients based on project length), draft and beam."
+msgstr ""
+
+#: freestringsunit.rs_note_3__the_bulb_characteristics_was_calculated_right__if_f_p__is_through_point_of_intersection
+msgid ""
+"Note 3: The bulb characteristics was calculated right, if F.P. is through "
+"point of intersection"
+msgstr ""
+
+#: freestringsunit.rs_note__appendage_resistance_is_calculated_for_stationary_engine
+msgid "NOTE: Appendage resistance is calculated for stationary engine"
+msgstr ""
+
+#: freestringsunit.rs_note__coefficients_wt__t_and_etar_were_calculated_by_formulaes_of_method_holtrop_
+msgid ""
+"NOTE: Coefficients Wt, t and EtaR were calculated by formulaes of method "
+"Holtrop-"
+msgstr ""
+
+#: freestringsunit.rs_note__coefficients__wt_t_nr_cp_opt_lcb_opt__are_calculated_for_speed_vs__
+msgid ""
+"Note: Coefficients (Wt,t,nr,Cp_opt,Lcb_opt) are calculated for speed Vs ="
+msgstr ""
+
+#: freestringsunit.rs_note__in_parentheses_the_minimum_values_of_demanded_parameters_are_specified
+msgid ""
+"Note: In parentheses the minimum values of demanded parameters are specified"
+msgstr ""
+
+#: freestringsunit.rs_note__propeller_s_metal___1_brass_mntfe__2_bronze_altfe_h9_4_4__3_carbon_steel_
+msgid ""
+"Note: Propeller's metal:  1-brass Mn+Fe; 2-bronze Al+Fe H9-4-4; 3-carbon "
+"steel;"
+msgstr ""
+
+#: freestringsunit.rs_not_all_points_could_be_added_while_collapsing_edge
+msgid "Not all points could be added while collapsing edge"
+msgstr ""
+
+#: freestringsunit.rs_not_modified
+msgid "not modified"
+msgstr ""
+
+#: freestringsunit.rs_no_faces_could_be_removed_
+msgid "No faces could be removed."
+msgstr ""
+
+#: freestringsunit.rs_no_geometry_imported_
+msgid "No geometry imported."
+msgstr ""
+
+#: freestringsunit.rs_no_intersection_points_found_
+msgid "No intersection points found."
+msgstr ""
+
+#: freestringsunit.rs_no_markers_could_be_imported_
+msgid "No markers could be imported."
+msgstr ""
+
+#: freestringsunit.rs_no_meshdata_could_be_imported
+msgid "No meshdata could be imported"
+msgstr ""
+
+#: freestringsunit.rs_no_points_to_transfom_in_the_current_selection
+msgid "No points to transfom in the current selection"
+msgstr ""
+
+#: freestringsunit.rs_no_printer_assigned
+msgid "No printer assigned"
+msgstr ""
+
+#: freestringsunit.rs_npb___
+msgid "NPB  ="
+msgstr ""
+
+#: freestringsunit.rs_number_of_a_ship_series
+msgid "Number of a ship series"
+msgstr ""
+
+#: freestringsunit.rs_number_of_blades
+msgctxt "freestringsunit.rs_number_of_blades"
+msgid "Number of blades"
+msgstr ""
+
+#: freestringsunit.rs_number_of_blades_is_out_of_limits_for_this_diagram___
+msgid "Number of blades is out of limits for this diagram!!!"
+msgstr ""
+
+#: freestringsunit.rs_number_of_columns
+msgid "Number of columns"
+msgstr ""
+
+#: freestringsunit.rs_number_of_desired_controlpoints_on_each_station
+msgid "Number of desired controlpoints on each station"
+msgstr ""
+
+#: freestringsunit.rs_number_of_diagram
+msgctxt "freestringsunit.rs_number_of_diagram"
+msgid "Number of diagram"
+msgstr ""
+
+#: freestringsunit.rs_number_of_hulls
+msgid "Number of hulls"
+msgstr ""
+
+#: freestringsunit.rs_number_of_masts_and_posts__1_7_
+msgid "Number of masts and posts (1-7)"
+msgstr ""
+
+#: freestringsunit.rs_number_of_propellers
+msgctxt "freestringsunit.rs_number_of_propellers"
+msgid "Number of propellers"
+msgstr ""
+
+#: freestringsunit.rs_number_of_propeller_blades_____________
+msgid "Number of Propeller Blades            ="
+msgstr ""
+
+#: freestringsunit.rs_number_of_prototype_in_bd__npr___0___20_
+msgid "Number of prototype in BD (Npr = 0...20)"
+msgstr ""
+
+#: freestringsunit.rs_number_of_rows
+msgid "Number of rows"
+msgstr ""
+
+#: freestringsunit.rs_number_of_station_for_sac_calculation_must_be___100_
+msgid "number of station for SAC calculation must be < 100!"
+msgstr ""
+
+#: freestringsunit.rs_off__bow________________error________________error________________error
+msgid "OFF  BOW                ERROR                ERROR                ERROR"
+msgstr ""
+
+#: freestringsunit.rs_ok__propeller_is_not_cavitate_
+msgid "OK! Propeller is not cavitate."
+msgstr ""
+
+#: freestringsunit.rs_old_backup_could_not_be_removed_
+msgid "Old backup could not be removed!"
+msgstr ""
+
+#: freestringsunit.rs_one_or_more_parameters_are_outside_valid_domain_
+msgid "One or more parameters are outside valid domain:"
+msgstr ""
+
+#: freestringsunit.rs_only_boundary_edges_can_be_extruded_
+msgid "Only boundary edges can be extruded!"
+msgstr ""
+
+#: freestringsunit.rs_only_the_first_10_are_shown
+msgid "Only the first 10 are shown"
+msgstr ""
+
+#: freestringsunit.rs_open_water_characteristics_of_propeller
+msgid "Open water characteristics of propeller"
+msgstr ""
+
+#: freestringsunit.rs_optimal_advance_coeffic___jp_opt__
+msgid "Optimal advance coeffic.  Jp_opt ="
+msgstr ""
+
+#: freestringsunit.rs_optimal_design_results_
+msgid "Optimal Design Results:"
+msgstr ""
+
+#: freestringsunit.rs_optimization_search_evaluation_count_____
+msgid "Optimization Search Evaluation Count    ="
+msgstr ""
+
+#: freestringsunit.rs_oriented_bulbous_mass
+msgid "Oriented bulbous mass"
+msgstr ""
+
+#: freestringsunit.rs_parameters_of_ship_sinkage_
+msgid "Parameters of ship sinkage:"
+msgstr ""
+
+#: freestringsunit.rs_part
+msgid "Part"
+msgstr ""
+
+#: freestringsunit.rs_permissible_wind_speed
+msgid "Permissible wind speed"
+msgstr ""
+
+#: freestringsunit.rs_perspective_view
+msgid "Perspective view"
+msgstr ""
+
+#: freestringsunit.rs_pitch_diameter_ratio
+msgid "Pitch-diameter ratio"
+msgstr ""
+
+#: freestringsunit.rs_pitch_diameter_ratio_p_dp________________
+msgid "Pitch Diameter Ratio P/Dp               ="
+msgstr ""
+
+#: freestringsunit.rs_plan_view
+msgctxt "freestringsunit.rs_plan_view"
+msgid "Plan view"
+msgstr ""
+
+#: freestringsunit.rs_points
+msgid "points"
+msgstr ""
+
+#: freestringsunit.rs_points_removed_
+msgid "points removed."
+msgstr ""
+
+#: freestringsunit.rs_points_unlocked
+msgid "points unlocked"
+msgstr ""
+
+#: freestringsunit.rs_point_move
+msgctxt "freestringsunit.rs_point_move"
+msgid "point move"
+msgstr ""
+
+#: freestringsunit.rs_possible_inaccurate_ssd_calculation__increase_the_maximum_angle_of_heel_
+msgid ""
+"Possible inaccurate SSD calculation: Increase the maximum angle of heel!"
+msgstr ""
+
+#: freestringsunit.rs_power
+msgctxt "freestringsunit.rs_power"
+msgid "Power"
+msgstr ""
+
+#: freestringsunit.rs_power_of_main_engine__kw___pe___thrust__kn___te
+msgid "Power of main engine, kW - Pe;  Thrust, kN - Te"
+msgstr ""
+
+#: freestringsunit.rs_power_of_main_engine__w____pe___thrust__n____te
+msgid "Power of main engine [W] - Pe;  Thrust [N] - Te"
+msgstr ""
+
+#: freestringsunit.rs_ppd___
+msgid "PPD  ="
+msgstr ""
+
+#: freestringsunit.rs_print_scale
+msgid "Print scale"
+msgstr ""
+
+#: freestringsunit.rs_prismatic_coefficient
+msgctxt "freestringsunit.rs_prismatic_coefficient"
+msgid "Prismatic coefficient"
+msgstr "Coeficiente Prismático"
+
+#: freestringsunit.rs_prismatic_coefficient_on_lwl________cp__
+msgid "Prismatic Coefficient on LWL        CP ="
+msgstr ""
+
+#: freestringsunit.rs_profile_view
+msgid "Profile view"
+msgstr ""
+
+#: freestringsunit.rs_program_of_aerodynamics_characteristics_calculation_for_merchant_ships_
+msgid "Program of aerodynamics characteristics calculation for merchant ships."
+msgstr ""
+
+#: freestringsunit.rs_program_of_resistance_and_power_prediction_for_naval_ships__nuos_ukraine_2010_
+msgid ""
+"Program of resistance and power prediction for naval ships "
+"(NUoS,Ukraine,2010)"
+msgstr ""
+
+#: freestringsunit.rs_program_of_resistance_and_power_prediction_for_tugs_and_trawlers__nuos__ukraine_2009_
+msgid ""
+"Program of resistance and power prediction for tugs and trawlers (NUoS, "
+"Ukraine,2009)"
+msgstr ""
+
+#: freestringsunit.rs_program_of_resistance_prediction_for_cargo_ships_by_hollenbach_1998_method__nuos__ukraine_
+msgid ""
+"Program of resistance prediction for cargo ships by Hollenbach-1998 method "
+"(NUoS, Ukraine)"
+msgstr ""
+
+#: freestringsunit.rs_program_of_resistance_prediction_for_displacement_ships_hydronship_v1_08__nuos__ukraine_
+msgid ""
+"Program of resistance prediction for displacement ships HydroNShIp v1.08 "
+"(NUoS, Ukraine)"
+msgstr ""
+
+#: freestringsunit.rs_program_of_resistance_prediction_planing_and_pre_planing_ships
+msgid "Program of resistance prediction planing and pre-planing ships"
+msgstr ""
+
+#: freestringsunit.rs_project
+msgctxt "freestringsunit.rs_project"
+msgid "Project"
+msgstr ""
+
+#: freestringsunit.rs_project_settings
+msgid "project settings"
+msgstr ""
+
+#: freestringsunit.rs_propeller
+msgid "PROPELLER"
+msgstr ""
+
+#: freestringsunit.rs_propeller_characteristics_are_
+msgid "Propeller characteristics are:"
+msgstr ""
+
+#: freestringsunit.rs_propeller_diameter_dp__m_________________
+msgid "Propeller Diameter Dp (m)               ="
+msgstr ""
+
+#: freestringsunit.rs_propeller_diameter__m___________________
+msgid "Propeller Diameter (m)                 ="
+msgstr ""
+
+#: freestringsunit.rs_propeller_efficiency_eta0
+msgid "Propeller efficiency Eta0"
+msgstr ""
+
+#: freestringsunit.rs_propeller_expanded_area_ratio_ae_ao_____
+msgid "Propeller Expanded Area Ratio Ae/Ao    ="
+msgstr ""
+
+#: freestringsunit.rs_propeller_is_a_strong_in_non_uniform_flow_
+msgid "Propeller is a strong in non-uniform flow."
+msgstr ""
+
+#: freestringsunit.rs_propeller_is_a_strong_in_uniform_flow_
+msgid "Propeller is a strong in uniform flow."
+msgstr ""
+
+#: freestringsunit.rs_propeller_open_water_efficiency_eta0_____
+msgid "Propeller Open Water Efficiency Eta0    ="
+msgstr ""
+
+#: freestringsunit.rs_propeller_pitch_diameter_ratio_p_dp_____
+msgid "Propeller Pitch Diameter Ratio P/Dp    ="
+msgstr ""
+
+#: freestringsunit.rs_propeller_pitch_p__m_____________________
+msgid "Propeller Pitch P (m)                   ="
+msgstr ""
+
+#: freestringsunit.rs_propeller_power__kw___________pd__
+msgid "Propeller power [kW]          Pd ="
+msgstr ""
+
+#: freestringsunit.rs_propeller_propulsive_power__kw_________
+msgid "Propeller Propulsive Power [kW]       ="
+msgstr ""
+
+#: freestringsunit.rs_propeller_revolutions_per_minute__rpm____
+msgid "Propeller Revolutions per Minute (rpm)  ="
+msgstr ""
+
+#: freestringsunit.rs_propeller_shaft_power__kw______________
+msgid "Propeller Shaft Power [kW]            ="
+msgstr ""
+
+#: freestringsunit.rs_propeller_task1_note
+msgctxt "freestringsunit.rs_propeller_task1_note"
+msgid ""
+"Table.      Middle meanings of efficiency shaft and gearbox\n"
+"----------------------------------+--------------------------------------\n"
+"Type of thrust bearing            |        Shaft efficiency\n"
+"----------------------------------+--------------------------------------\n"
+"ring-type                         |              0,95\n"
+"Michell                           |              0,97\n"
+"ball-bearing or roller bearing    |          0,96...0,98\n"
+"----------------------------------+--------------------------------------\n"
+"Type of transmission              |     Transmission efficiency\n"
+"----------------------------------+--------------------------------------\n"
+"toothed single-reduction gearbox  |          0,97...0,99\n"
+"toothed double-reduction gearbox  |          0,94...0,97\n"
+"fluid flywheel                    |          0,95...0,97\n"
+"magnetics                         |          0,96...0,98\n"
+"----------------------------------+--------------------------------------\n"
+"Type of electrotransmission       | Shaft efficiency * Gearbox efficiency\n"
+"----------------------------------+--------------------------------------\n"
+"direct current                    |          0,86...0,90\n"
+"alternating current               |          0,83...0,93\n"
+"----------------------------------+--------------------------------------\n"
+"Table.       Main characteristics of propellers and series numbers\n"
+"+---+---------------------------+-----+-------------+-----------+-----+------"
+"+----+\n"
+"|Num|          Series           |  Z  |    Ae/Ao    |    P/D    | e/D | dh/D "
+"|Hi,°|\n"
+"+---+---------------------------+-----+-------------+-----------+-----+------"
+"+----+\n"
+"| 1 |B-Wageningen basin         |2...6|0,3  ... 1,05|0,6 ... 1,4|0,050|0,180 "
+"| 15 |\n"
+"| 2 |B-Wageningen basin         |  4  |0,4  ... 1,0 |0,6 ... 1,4|0,045|0,167 "
+"| 15 |\n"
+"| 3 |B-Wageningen basin         |  5  |0,45 ... 1,05|0,6 ... 1,4|0,040|0,167 "
+"| 15 |\n"
+"| 4 |B-Wageningen basin         |  6  |     0,8     |0,5 ... 1,4|0,040|0,167 "
+"| 15 |\n"
+"| 5 |T-Titov                    |  4  |     0,58    |0,6 ... 1,5| 0,06|0,200 "
+"|  0 |\n"
+"| 6 |T-Titov                    |  4  |     0,75    |0,6 ... 1,5| 0,06|0,200 "
+"|  0 |\n"
+"| 7 |M-Mishkevich               |  4  |     0,65    |0,6 ... 1,4| 0,06|0,200 "
+"|  5 |\n"
+"| 8 |Z-Zavadovsky               |  4  |     0,85    |0,9 ... 1,4|0,045|0,180 "
+"| 15 |\n"
+"| 9 |Z-Zavadovsky               |  4  |     1,0     |0,9 ... 1,4|0,045|0,180 "
+"| 15 |\n"
+"|10 |T-Titov                    |  4  |     0,35    |0,6 ... 1,5| 0,06|0,200 "
+"|  0 |\n"
+"|11 |Fixed pitch ducted propel. |  4  |     0,35    |0,7 ... 1,5| 0,06|0,200 "
+"|  0 |\n"
+"|12 |Fixed pitch ducted propel. |  4  |     0,58    |0,7 ... 1,5| 0,06|0,200 "
+"|  0 |\n"
+"|13 |Fixed pitch ducted propel. |  4  |     0,75    |0,7 ... 1,5| 0,06|0,200 "
+"|  0 |\n"
+"|14 |CP ducted propeller l=0,6  |  4  |     0,57    |0,5 ... 1,8| 0,06|0,317 "
+"|  0 |\n"
+"|15 |CP ducted propeller l=0,8  |  4  |     0,57    |0,5 ... 1,5| 0,06|0,317 "
+"|  0 |\n"
+"|16 |Fixed pitch ducted propel. |  4  |     0,57    |0,5 ... 1,5| 0,06|0,180 "
+"|  0 |\n"
+"|17 |Contra-rotat.propeller 1(2)|  4  | 0,575(0,545)|0,8 ... 1,5|     |0,200 "
+"|  0 |\n"
+"+---+---------------------------+-----+-------------+-----------+-----+------"
+"+----+\n"
+"\n"
+"Note: More information see in book: Raschet Hodkosti nudvodnych "
+"vodoizmeschayuschich sudov:\n"
+"Uchebnoe posobie/ M.B.Slizghevski, Yu.M.Korol, M.G.Sokolik, V.F.Timoshenko;\n"
+"Under common redaction by Prof. M.B.Slizghevski.-Nikolaev, NUoS, 2004.-192p."
+msgstr ""
+
+#: freestringsunit.rs_propeller_task2_note
+msgctxt "freestringsunit.rs_propeller_task2_note"
+msgid ""
+"Table.      Middle meanings of efficiency shaft and gearbox\n"
+"----------------------------------+--------------------------------------\n"
+"Type of thrust bearing            |        Shaft efficiency\n"
+"----------------------------------+--------------------------------------\n"
+"ring-type                         |              0,95\n"
+"Michell                           |              0,97\n"
+"ball-bearing or roller bearing    |          0,96...0,98\n"
+"----------------------------------+--------------------------------------\n"
+"Type of transmission              |     Transmission efficiency\n"
+"----------------------------------+--------------------------------------\n"
+"toothed single-reduction gearbox  |          0,97...0,99\n"
+"toothed double-reduction gearbox  |          0,94...0,97\n"
+"fluid flywheel                    |          0,95...0,97\n"
+"magnetics                         |          0,96...0,98\n"
+"----------------------------------+--------------------------------------\n"
+"Type of electrotransmission       | Shaft efficiency * Gearbox efficiency\n"
+"----------------------------------+--------------------------------------\n"
+"direct current                    |          0,86...0,90\n"
+"alternating current               |          0,83...0,93\n"
+"----------------------------------+--------------------------------------\n"
+"Table.       Main characteristics of propellers and series numbers\n"
+"+---+---------------------------+-----+-------------+-----------+-----+------"
+"+----+\n"
+"|Num|          Series           |  Z  |    Ae/Ao    |    P/D    | e/D | dh/D "
+"|Hi,°|\n"
+"+---+---------------------------+-----+-------------+-----------+-----+------"
+"+----+\n"
+"| 1 |B-Wageningen basin         |2...6|0,3  ... 1,05|0,6 ... 1,4|0,050|0,180 "
+"| 15 |\n"
+"| 2 |B-Wageningen basin         |  4  |0,4  ... 1,0 |0,6 ... 1,4|0,045|0,167 "
+"| 15 |\n"
+"| 3 |B-Wageningen basin         |  5  |0,45 ... 1,05|0,6 ... 1,4|0,040|0,167 "
+"| 15 |\n"
+"| 4 |B-Wageningen basin         |  6  |     0,8     |0,5 ... 1,4|0,040|0,167 "
+"| 15 |\n"
+"| 5 |T-Titov                    |  4  |     0,58    |0,6 ... 1,5| 0,06|0,200 "
+"|  0 |\n"
+"| 6 |T-Titov                    |  4  |     0,75    |0,6 ... 1,5| 0,06|0,200 "
+"|  0 |\n"
+"| 7 |M-Mishkevich               |  4  |     0,65    |0,6 ... 1,4| 0,06|0,200 "
+"|  5 |\n"
+"| 8 |Z-Zavadovsky               |  4  |     0,85    |0,9 ... 1,4|0,045|0,180 "
+"| 15 |\n"
+"| 9 |Z-Zavadovsky               |  4  |     1,0     |0,9 ... 1,4|0,045|0,180 "
+"| 15 |\n"
+"|10 |T-Titov                    |  4  |     0,35    |0,6 ... 1,5| 0,06|0,200 "
+"|  0 |\n"
+"|11 |Fixed pitch ducted propel. |  4  |     0,35    |0,7 ... 1,5| 0,06|0,200 "
+"|  0 |\n"
+"|12 |Fixed pitch ducted propel. |  4  |     0,58    |0,7 ... 1,5| 0,06|0,200 "
+"|  0 |\n"
+"|13 |Fixed pitch ducted propel. |  4  |     0,75    |0,7 ... 1,5| 0,06|0,200 "
+"|  0 |\n"
+"|14 |CP ducted propeller l=0,6  |  4  |     0,57    |0,5 ... 1,8| 0,06|0,317 "
+"|  0 |\n"
+"|15 |CP ducted propeller l=0,8  |  4  |     0,57    |0,5 ... 1,5| 0,06|0,317 "
+"|  0 |\n"
+"|16 |Fixed pitch ducted propel. |  4  |     0,57    |0,5 ... 1,5| 0,06|0,180 "
+"|  0 |\n"
+"|17 |Contra-rotat.propeller 1(2)|  4  | 0,575(0,545)|0,8 ... 1,5|     |0,200 "
+"|  0 |\n"
+"+---+---------------------------+-----+-------------+-----------+-----+------"
+"+----+\n"
+"\n"
+"Note: More information see in book: Raschet Hodkosti nudvodnych "
+"vodoizmeschayuschich sudov:\n"
+"Uchebnoe posobie/ M.B.Slizghevski, Yu.M.Korol, M.G.Sokolik, V.F.Timoshenko;\n"
+"Under common redaction by Prof. M.B.Slizghevski.-Nikolaev, NUoS, 2004.-192p."
+msgstr ""
+
+#: freestringsunit.rs_propeller_task4_note
+msgctxt "freestringsunit.rs_propeller_task4_note"
+msgid ""
+"PROPELLER OPTIMIZATION PROGRAM (POP.1.5)\n"
+"M. G. Parsons, December, 1994\n"
+"1. METHODS:\n"
+"1.1    This program implements the Wageningen B-Screw Series regression "
+"equations presented\n"
+"by Oosterveld and van Oossanen [1]. The user can  either  evaluate a given "
+"propeller or use\n"
+"mathematical programming from Parsons [2] to  obtain  the  optimum  open  "
+"water  efficiency\n"
+"propeller for a given application.\n"
+"1.2   In the optimization mode, the user specifies the required thrust and "
+"speed of advance.\n"
+"The program then uses the Nelder and Mead Simplex Search method with  an  "
+"External  Penalty\n"
+"Function [2] to  determine  the  optimum  propeller. Wageningen  B-Screw  "
+"Series 3- through\n"
+"7-bladed propellers with Reynolds  number  corrections  are  available. "
+"Optimization  among\n"
+"blade number must be handled with separate runs for  each  blade  number  "
+"and  then  simple\n"
+"comparison. For  controllable-reversible-pitch  propeller  estimates, the  "
+"program  reduces\n"
+"the B-Screw Series open water efficiency  by 2 percent. The  program  "
+"includes  either  the\n"
+"Burrill five or ten percent back  cavitation  criterion [3]. The  "
+"optimization  independent\n"
+"variables are the expanded  area  ratio  Ae/Ao, the  pitch-diameter  ratio  "
+"P/Dp,  and  the\n"
+"propeller diameter Dp. The propeller RPM needed to produce  the  specified  "
+"thrust  (within\n"
+"about 1 lbf.) is determined at each step of the search in an internal loop. "
+"Thus,instead of\n"
+"having  RPM  as a fourth independent variable, it is established by the "
+"equality constraint\n"
+"that the produced  thrust must equal the required thrust. This is an "
+"implicit constraint so\n"
+"the required RPM is found by an iteration. The constraints on the variables "
+"are as follows:\n"
+"__3 <= Nblade <= 7;\n"
+"0.3 <=  Ae/Ao <= 1.05;\n"
+"0.5 <=  P/Dp  <= 1.40;\n"
+"Dpmin <= Dp   <= Dpmax;\n"
+"0.0  <=   J   <= 1.60;\n"
+"1 <= thrust loading <= 2 - by Burrill 5% or 10% limit.\n"
+"\n"
+"1.4 The optimization is for the maximum open water  efficiency  propeller "
+"that will produce\n"
+"the required thrust at the specified speed  of  advance. The  Burrill  5%  "
+"back  cavitation\n"
+"criterion is recommended. The program does  not  check  to  see  that  the "
+"resulting design\n"
+"is \"slightly to the left\" of the peak of the efficiency versus  J  "
+"diagram  as  is  usually\n"
+"recommended as margin if the  design  misses  the  predicted  operating "
+"point RPM. The user\n"
+"should check this on the graphical output.\n"
+"1.5 An error message will be  printed if the determination of the RPM needed "
+"to produce the\n"
+"required thrust does not converge within 400 iterations within the "
+"computations.\n"
+"1.6 Propeller Type allows the selection of a fixed-pitch or controllable-"
+"pitch propeller.\n"
+"At this time, only the Wageningen B-Screw Series is supported and the open "
+"water efficiency\n"
+"is reduced by 2 percent  for  the controllable-pitch propeller option to "
+"reflect the larger\n"
+"hub.\n"
+"1.7 Propeller Characteristics  obtains  the  blade  number and the basic "
+"parameters for the\n"
+"propeller. If the optimization option is being used, the parameters are the "
+"initial  values\n"
+"used by the search algorithm. If the evaluation option is  being used, the  "
+"parameters  are\n"
+"those evaluated by the program.\n"
+"1.7.1 Nblade number of blades on propeller, 3 through 7 supported.\n"
+"1.7.2 Ae/Ao initial point for search or evaluated expanded area ratio.\n"
+"1.7.3 P/Dp initial point for search or evaluated pitch diameter ratio.\n"
+"1.7.4 Dp initial point for search or evaluated propeller diameter in "
+"meters.\n"
+"1.8 Operating  Conditions  obtains the ship speed, wake fraction, and thrust "
+"required from\n"
+"the propeller. It also allows  the  selection  of  the  5%  or  10% Burrill "
+"back cavitation\n"
+"constraint and obtains  the  submergence  of  the  shaft centerline needed "
+"to calculate the\n"
+"Cavitation Number at the blade tip.\n"
+"1.8.1 THR required thrust per propeller in kilonewtons, THR = Rt/Zp/(1 - "
+"t);\n"
+"1.8.2 Vk - ship speed in knots;\n"
+"1.8.3 w - average longitudinal wake fraction;\n"
+"1.8.4 HWLM - depth of shaft centerline below waterline in meters.\n"
+"1.9 Water Properties allows the choice of fresh water @ 15C, salt water @ "
+"15C or user-spe-\n"
+"cified water properties.\n"
+"1.10 When the optimization is selected, a minimum and maximum propeller  "
+"diameter  must  be\n"
+"specified. The user can also enter a run specific identifier at this point, "
+"if desired.\n"
+"1.10.1 Dpmin - Minimum propeller diameter in meters. Typically this is about "
+"25% of Dpmax for\n"
+"fixed-pitch propellers and about 35% of Dpmax for controllable-pitch "
+"propellers.\n"
+"1.10.2 Dpmax - Maximum propeller diameter permitted by hull and required "
+"clearances,in meters.\n"
+"1.11 When the analysis process is completed, the program can be produce an "
+"open water efficiency,\n"
+"KT, and KQ versus J and plot graphics.\n"
+"REFERENCES:\n"
+"1.Oosterveld, M. W. C., and  van Oossanen, P. , \" Further  Computer-"
+"Analyzed  Data  of  the\n"
+"Wageningen B-Screw Series,\" International Shipbuilding Progress, Vol.22, "
+"No.251, July,1975.\n"
+"2.Parsons, M. G., \"Optimization Methods for Use in Computer-Aided Ship "
+"Design,\" Proceedings\n"
+"of the First SNAME STAR Symposium, 1975.\n"
+"3.Comstock,J.P. (Ed.), Principles of Naval Architecture, Vol. II, 1988  "
+"Edition, SNAME, New\n"
+"York, p.182."
+msgstr ""
+
+#: freestringsunit.rs_propeller_task5_note
+msgid ""
+"1.1   This program calculates the open water characteristics of a fixed-"
+"pitch full-scale\n"
+"propeller,as published by:\n"
+"*     M.W.C.Oosterveld and P. van Oossanen. Further Computer-Analyzed Data "
+"of Wageningen\n"
+"B-Screw Series. I.S.P., Vol. 22, No. 251, July 1975.\n"
+"N.M.S.B., Report No. 479.\n"
+"1.2   Also the program calculates for each RPM the coefficients of a third "
+"degree  poly-\n"
+"nomial, expressed in the speed ratio J.\n"
+"1.3   When decreasing the thrust and the  efficiency  by  approximately  3  "
+"percent, the\n"
+"results can be used for a controllable pitch propeller without a nozzle.\n"
+"1.4   This is program modification calculates zero thrust and torque "
+"advances,\n"
+"optimal advance Jopt and maximal efficiency Eta0_max of propeller series B.\n"
+"1.5   The characteristics of a propeller series B set are as follows:\n"
+"1.5.1    3 <= Nblade <= 7;  0,3 <=  Ae/Ao <= 1,05;  0,5 <=  P/Dp  <= 1,40 ;\n"
+"1.6   The advance coefficient is as follow: 0 <=  Jp=Vp/n/Dp <= 1,6.\n"
+"1.7   Main parameters of fixed pitch propellers of T,M,Z,ZM series:\n"
+"+---------------------------------------+---+--------------+---------+\n"
+"|            S E R I E S                | Z |     Ae/Ao    |   P/D   |\n"
+"|---------------------------------------+---+--------------+---------|\n"
+"| I.Titov          T-4-35 T-4-58 T-4-75 | 4 |0.35 0.58 0.75|0.70-1.50|\n"
+"| V.Mishkevich     M-4-65 M-4-75 M-4-85 | 4 |0.65 0.75 0.85|0.60-1.40|\n"
+"| M.Zavadovsky           Z-4-85 Z-4-100 | 4 |   0.85, 1.0  |0.90-1.40|\n"
+"| KSRI-BIHS    ZM-5-70 ZM-5-85 ZM-5-100 | 5 |0.70 0.85 1.0 |0.80-1.35|\n"
+"| V.Turbal                       T-6-68 | 6 |    0.680     |0.40-1.36|\n"
+"| V.Turbal                       T-7-70 | 7 |    0.700     |0.50-1.30|\n"
+"| V.Turbal                       T-8-72 | 8 |    0.720     |0.50-1.30|\n"
+"+---------------------------------------+---+--------------+---------+"
+msgstr ""
+
+#: freestringsunit.rs_propeller_thrust__kn___________t__
+msgid "Propeller thrust [kN]          T ="
+msgstr ""
+
+#: freestringsunit.rs_propeller_thrust__kn_____________________
+msgid "Propeller Thrust (kN)                   ="
+msgstr ""
+
+#: freestringsunit.rs_propeller_torque__knom_________q__
+msgid "Propeller torque [kN*m]        Q ="
+msgstr ""
+
+#: freestringsunit.rs_propeller_torque__knom_________________
+msgid "Propeller Torque [kN*m]               ="
+msgstr ""
+
+#: freestringsunit.rs_propulsion_type_________________________
+msgid "Propulsion Type                        ="
+msgstr ""
+
+#: freestringsunit.rs_prototype_of_river_ship__npr___1___
+msgid "Prototype of river ship (Npr = 1..."
+msgstr ""
+
+#: freestringsunit.rs_recomendations_for
+msgid "Recomendations for"
+msgstr ""
+
+#: freestringsunit.rs_redo
+msgctxt "freestringsunit.rs_redo"
+msgid "Redo"
+msgstr ""
+
+#: freestringsunit.rs_rel_wind_______coeff____stand_______coeff____stand_______coeff____stand
+msgid "REL WIND       COEFF    STAND       COEFF    STAND       COEFF    STAND"
+msgstr ""
+
+#: freestringsunit.rs_remaining_resistance_components__n__
+msgid "Remaining Resistance Components (N):"
+msgstr ""
+
+#: freestringsunit.rs_remove_starboard_side
+msgid "remove starboard side"
+msgstr ""
+
+#: freestringsunit.rs_remove_unused_points
+msgid "remove unused points"
+msgstr ""
+
+#: freestringsunit.rs_required_area_of_gz_curve_from_0__to_30_
+msgid "Required area of GZ curve from 0° to 30°"
+msgstr ""
+
+#: freestringsunit.rs_required_area_of_gz_curve_from_0__to_40_
+msgid "Required area of GZ curve from 0° to 40°"
+msgstr ""
+
+#: freestringsunit.rs_required_area_of_gz_curve_from_30__to_40_
+msgid "Required area of GZ curve from 30° to 40°"
+msgstr ""
+
+#: freestringsunit.rs_required_propeller_thrust__kn__________
+msgid "Required Propeller Thrust (kN)        ="
+msgstr ""
+
+#: freestringsunit.rs_resistance
+msgctxt "freestringsunit.rs_resistance"
+msgid "Resistance"
+msgstr "Resistência ao avanço"
+
+#: freestringsunit.rs_resistanceo0_1__lbf___power__ehp_
+msgid "Resistance*0.1 [lbf]; Power [ehp]"
+msgstr "Resistência*0.1 [lbf]; Potência [ehp]"
+
+#: freestringsunit.rs_resistanceo10__kn___power__kw_
+msgid "Resistance*10 [kN]; Power [kW]"
+msgstr "Resistência*10 [kN]; Potência [kW]"
+
+#: freestringsunit.rs_resistance_
+msgid "Resistance:"
+msgstr "Resistência ao avanço:"
+
+#: freestringsunit.rs_resistance_and_power_are_calculated
+msgid "Resistance and power are calculated"
+msgstr "Resistência e potência são calculadas"
+
+#: freestringsunit.rs_resistance_and_power_for_small_displacement_ships_by_ubc_1993_method
+msgid "Resistance and power for small displacement ships by UBC-1993 method"
+msgstr ""
+
+#: freestringsunit.rs_resistance_and_power_of_tugs_and_trawlers_by_ridgeley_nevitt_1967_method
+msgid ""
+"Resistance and power of tugs and trawlers by Ridgeley-Nevitt-1967 method"
+msgstr ""
+
+#: freestringsunit.rs_resistance_and_power_planing_ships_by_clement_blount_method
+msgid "Resistance and power planing ships by Clement-Blount method"
+msgstr ""
+
+#: freestringsunit.rs_resistance_and_power_planing_ships_by_clement_poup_method
+msgid "Resistance and power planing ships by Clement-Poup method"
+msgstr ""
+
+#: freestringsunit.rs_resistance_and_power_planing_ships_by_compton_s_method
+msgid "Resistance and power planing ships by Compton's method"
+msgstr ""
+
+#: freestringsunit.rs_resistance_and_power_planing_ships_by_d_savitsky_s_method__1964_
+msgid "Resistance and power planing ships by D.Savitsky's method (1964)"
+msgstr ""
+
+#: freestringsunit.rs_resistance_and_power_planing_ships_by_radojcic_method
+msgid "Resistance and power planing ships by Radojcic method"
+msgstr ""
+
+#: freestringsunit.rs_resistance_and_power_planing_ships_by_robinson_s_method__wolfson_1999_
+msgid "Resistance and power planing ships by Robinson's method (Wolfson-1999)"
+msgstr ""
+
+#: freestringsunit.rs_resistance_and_power_pre_planing_ships_by_method_of_mercier_savitsky
+msgid "Resistance and power pre-planing ships by method of Mercier-Savitsky"
+msgstr ""
+
+#: freestringsunit.rs_resistance_and_power_pre_planing_ships_by_m_bunkov_method
+msgid "Resistance and power pre-planing ships by M.Bunkov method"
+msgstr ""
+
+#: freestringsunit.rs_resistance_fungleib_note_p5
+msgid ""
+"5.Standart deviation of database for typical resistance Fung-Leibman's "
+"method:\n"
+"+-----------------------------+----------------------+\n"
+"|        Parameters           |      Limitations     |\n"
+"|-----------------------------+----------------------|\n"
+"| Length/Breadth,       Lwl/B |  2.520 to 17.935     |\n"
+"| Breadth/Draft,          B/T |  1.696 to 10.204     |\n"
+"| Prismatic coefficient,   Cp |  0.526 to 0.774      |\n"
+"| Midship coefficient,     Cm |  0.556 to 0.994      |\n"
+"| Waterplane coefficient, Cwp |  0.662 to 0.841      |\n"
+"| Half entrance angle,     ie |    2.6 to 31.73 degr |\n"
+"| Transom area coefficient Ta |   0.00 to 0.74       |\n"
+"| Transom beam coefficient Tw |   0.00 to 1.00       |\n"
+"| Disp/length, DLR=V/Lwl^3    |  16.24 to 359.2      |\n"
+"| Froude number, Fr           |   0.15 to 0.90       |\n"
+"+-----------------------------+----------------------+"
+msgstr ""
+
+#: freestringsunit.rs_resistance_hollen_note_p5
+msgid ""
+"5.Standart deviation of database for typical resistance Hollenbach's "
+"method:\n"
+"+-------------+----------------------------------------+-------------------"
+"+\n"
+"|             |            Single-screw ship           |                   "
+"|\n"
+"| Character.  |-------------------+--------------------+  Twin-screw ship  "
+"|\n"
+"|             |    Design draft   |   Ballast draft    |                   "
+"|\n"
+"+-------------+-------------------+--------------------+-------------------"
+"+\n"
+"| L/V**0,3333 |  4,490 ... 6,008  |  5,450 ... 7,047   |  4,405 ... 7,265  "
+"|\n"
+"|     Cb      |  0,601 ... 0,830  |  0,559 ... 0,790   |  0,512 ... 0,775  "
+"|\n"
+"|     L/B     |  4,710 ... 7,106  |  4,949 ... 6,623   |  3,960 ... 7,130  "
+"|\n"
+"|     B/T     |  1,989 ... 4,002  |  2,967 ... 6,120   |  2,308 ... 6,110  "
+"|\n"
+"|   Los/Lwl   |  1,000 ... 1,050  |  1,000 ... 1,050   |  1,000 ... 1,050  "
+"|\n"
+"|   Lwl/L     |  1,000 ... 1,055  |  0,945 ... 1,000   |  1,000 ... 1,070  "
+"|\n"
+"|    Dp/Ta    |  0,430 ... 0,840  |  0,655 ... 1,050   |  0,495 ... 0,860  "
+"|\n"
+"+-------------+-------------------+--------------------+-------------------+"
+msgstr ""
+
+#: freestringsunit.rs_resistance_holtrop_note_p1
+msgid ""
+"1.Viscosity by default is for sea water with density 1025 kg/m^3 and "
+"temperature 15 °C.\n"
+"You can change the temperature and the density: Project->Project Settings-"
+">Hydrostatics\n"
+msgstr ""
+
+#: freestringsunit.rs_resistance_holtrop_note_p2
+msgid "2.The trim is calculated by formulaes: dT=Tf-Ta, Tf=T+dt/2, Ta=T-dt/2\n"
+msgstr ""
+
+#: freestringsunit.rs_resistance_holtrop_note_p3
+msgctxt "freestringsunit.rs_resistance_holtrop_note_p3"
+msgid ""
+"3.Coefficient influence the after body form is from table:\n"
+"+-------------------------------------------------------"
+"+-------------------------+\n"
+"|                After body form                        |          "
+"Cstrn          |\n"
+"+-------------------------------------------------------"
+"+-------------------------+\n"
+"|              Normal sections                          |            "
+"0            |\n"
+"|              V-shaped sections                        |           "
+"-10           |\n"
+"|              U-shaped sections  (with Hogner stern)   |          5  "
+"( 10 )      |\n"
+"|              Barge type form                          |        -20  or "
+"-25      |\n"
+"+-------------------------------------------------------"
+"+-------------------------+"
+msgstr ""
+
+#: freestringsunit.rs_resistance_holtrop_note_p4
+msgctxt "freestringsunit.rs_resistance_holtrop_note_p4"
+msgid ""
+"4.If wetted surface area S is set as 0, then S to calculate by formulae from "
+"method of Holtrop."
+msgstr ""
+
+#: freestringsunit.rs_resistance_holtrop_note_p5
+msgctxt "freestringsunit.rs_resistance_holtrop_note_p5"
+msgid ""
+"5.The wetted area of transom you can determine from sectional areas curve on "
+"Profile View or\n"
+"from \"Design hydrostatics\" output.\n"
+"The wetted area of bulbous on F.P. is analogous determination.\n"
+"The CoG wetted bulb area h_b to determine on \"Bodyplan view\" visually."
+msgstr ""
+
+#: freestringsunit.rs_resistance_holtrop_note_p6
+msgctxt "freestringsunit.rs_resistance_holtrop_note_p6"
+msgid ""
+"6.Propeller number Np is set for power prediction and for interaction "
+"propeller and hull.\n"
+"For Np=0 the wake fraction Wt and thrust deduction t is calculated as for "
+"highspeed sailing\n"
+"ships."
+msgstr ""
+
+#: freestringsunit.rs_resistance_holtrop_note_p7
+msgid ""
+"7.Propeller diameter D with one-screw is <= 0.8*Ta, and for twin-screw <= "
+"0.7*Ta.\n"
+"Expanded blade area ratio Ae/Ao is calculate from condition, when cavitation "
+"be absent."
+msgstr ""
+
+#: freestringsunit.rs_resistance_holtrop_note_p8
+msgctxt "freestringsunit.rs_resistance_holtrop_note_p8"
+msgid "8.Absolutely rougness of hull less 150 mkm one can don't set."
+msgstr ""
+
+#: freestringsunit.rs_resistance_holtrop_note_p9
+msgid ""
+"9.    More information about statistical Holtrop method are here:\n"
+"9.1   Holtrop J., Mennen G.G.J., \"An  Approximate  Power  Prediction  "
+"Method\", \"International\n"
+"Shipbuilding Progress, Vol.29, No.335, July, 1982.\n"
+"9.2   Holtrop J., \"A Statistical Reanalysis of Resistance and Propulsion "
+"Data, \"International\n"
+"Shipbuilding Progress, Vol.31, No.363, Nov., 1984.\n"
+msgstr ""
+
+#: freestringsunit.rs_resistance_mh_note
+msgid ""
+"1.Viscosity by default is for sea water with density 1025 kg/m^3 and "
+"temperature 15 °C.\n"
+"You can change the temperature and the density: Project->Project Settings-"
+">Hydrostatics\n"
+"2.The trim is calculated by formulaes: dT=Tf-Ta, Tf=T+dt/2, Ta=T-dt/2\n"
+"3.Coefficient influence the after body form is from table:\n"
+"+-------------------------------------------------------"
+"+-------------------------+\n"
+"|                After body form                        |          "
+"Cstrn          |\n"
+"+-------------------------------------------------------"
+"+-------------------------+\n"
+"|              Normal sections                          |            "
+"0            |\n"
+"|              V-shaped sections                        |           "
+"-10           |\n"
+"|              U-shaped sections  (with Hogner stern)   |          5  "
+"( 10 )      |\n"
+"|              Barge type form                          |        -20  or "
+"-25      |\n"
+"+-------------------------------------------------------"
+"+-------------------------+\n"
+"4.In begining phase of ship design the wetted area S can be calculate for "
+"different types of ship and\n"
+"hulls on this formulaes:\n"
+"If S= 0, then S=L*(2*T+B)*sqrt(Cm)*(0,453+0,442*Cb-0,2862*Cm-0,003467*B/"
+"T+0,3696*Cwp) - by Holtrop\n"
+"If S=-1, then S=L*(1,36*T+1,13*Cb*B) - by Muragin's formulae for ships with "
+"Cb=0,4...0,5 and B/T=2,5...3,5\n"
+"If S=-2, then S=L*T*(2+1,37*(Cb-0,274)*B/T)     - by Semeka's formulae for "
+"ships with big Cb\n"
+"If S=-3, then S=L*(Cb*B+1,7*T)                  - by Moomford's formulae for "
+"Cb=0,7 and B/T=2...3\n"
+"If S=-4, then S=L*(B+2*T)*(0,76*Cb+0,28)        - by Benhe's formulae\n"
+"If S=-5, then S=L*(0,85*B+0,25*T)               - for ship with transom\n"
+"If S=-6, then S=V^0,6667*(5,1+0,074*L/T-0,4*Cb) - by Karpov's formulae for "
+"river ships w/o tonnels\n"
+"If S=-7, then S=Lpp*(0.5*B+T)*(0.55+1.52*Cb)    - by Yeroshin's formulae for "
+"fishing ships\n"
+"If S=-8, then S=V^0.3333*(3.4*V^0.3333+0.5*Lwl) - for cargo ships and "
+"ferries (Lap,1954)\n"
+"If S=-9, then S=V/B*1.7/[Cb-0.2*(Cb-0.65)]+B/T  - for cargo ships and "
+"ferries (Danckwardt,1969)\n"
+"If S=-10, then S=V/B*1.7/Cb+B/T*(0.92+0.092*Cb) - for trawlers "
+"(Danckwardt,1969)\n"
+"If S=-11, then S=Lpp*(1.8*T+B*Cb)               - for modern warships "
+"(Schneekluth,1988)\n"
+"If S=-12, then S=3,223*V^(2/3)+0,5402*Lwl*V^(1/3)- for tugs and trawlers "
+"(van Oortmerssen,1971)\n"
+"If S=-13, then S=V(1/T+1,75/B/Cb)                - by Grigoriev formulae\n"
+"If S=-14, then S=L(2*T + B)(0,654*Cb + 0,338)    - by Benge-Afanasiev "
+"formulae\n"
+"If S=-15, then S=(0,085*B/T-2*Cb+3,29)(V*L)^0,5  - by Vashedchenko-1985 "
+"formulae\n"
+"If S=-16, then S=L(2*T+B)(4,84*Cb-4,15*Cb^2-0,77)- for megayachts\n"
+"\n"
+"5.The wetted area of transom you can determine from sectional areas curve on "
+"Profile View or\n"
+"from \"Design hydrostatics\" output.\n"
+"The wetted area of bulbous on F.P. is analogous determination.\n"
+"The CoG wetted bulb area h_b to determine on \"Bodyplan view\" visually.\n"
+"6.Propeller number Np is set for power prediction and for interaction "
+"propeller and hull.\n"
+"For Np=0 the wake fraction Wt and thrust deduction t is calculated as for "
+"highspeed sailing\n"
+"ships.\n"
+"7.Propeller diameter D with one-screw is <= 0.8*Ta, and for twin-screw <= "
+"0.7*Ta.\n"
+"Expanded blade area ratio Ae/Ao is calculate from condition, when cavitation "
+"be absent.\n"
+"8.Absolutely rougness of hull less 150 mkm one can don't set.\n"
+"9. Limitations of resistance calculation by OCT 5.0181-75 (xUSSR) and "
+"another methods are:\n"
+"9.1 Series N 1 - high-speed and medium-rate ships: container carrier, Ro-Ro "
+"vessel, lighter carrier;\n"
+"9.2 Series N 2 - passenger and cargopassenger ships:\n"
+"9.3 Series N 3 - sea transport vessels: universal cargo vessels, middle "
+"tankers, bulkcarriers,\n"
+"transport fishing, refrigerator ships;\n"
+"9.4 Series N 4 - large displacement transport vessels: large tankers and ore-"
+"carriers;\n"
+"Table. Standart deviation of database for typical resistance of series by "
+"OCT 5.0181-75 method\n"
+"+-------------+-----------------+-----------------+-----------------"
+"+-----------------+\n"
+"|  Parameter  |    Series 1     |    Series 2     |   Series 3      |    "
+"Series 4     |\n"
+"+-------------+-----------------+-----------------+-----------------"
+"+-----------------+\n"
+"|  Cb         | 0,500 ... 0,650 | 0,550 ... 0,650 | 0,600 ... 0,800 | "
+"0,800 ... 0,875 |\n"
+"|  Lpp/B      |  4,80 ... 7,00  |  4,80 ... 7,30  |        -        |  "
+"5,80 ... 8,30  |\n"
+"|  B/T        |  2,00 ... 5,00  |  2,00 ... 5,00  |  2,00 ... 5,00  |  "
+"2,20 ... 3,50  |\n"
+"|  Xc/Lpp     |        -        | -0,05 ... 0,00  |-0,025 ... 0,030 | "
+"0,015 ... 0,044 |\n"
+"|Psi=L/V^0.333|        -        |        -        |        -        |  "
+"5,00 ... 7,50  |\n"
+"|  Fr         |  0,17 ... 0,34  |  0,17 ... 0,38  |  0,16 ... 0,30  |  "
+"0,10 ... 0,23  |\n"
+"|  Nser       |        1        |        2        |        3        |        "
+"4        |\n"
+"|  Np         |     1 ... 2     |        2        |        1        |        "
+"1        |\n"
+"|  Nf         |       2,4       |        2        |      1,2,4      |     "
+"2 ... 5     |\n"
+"|  Na         |        2        |        2        |        2        |     "
+"1 ... 3     |\n"
+"+-------------+-----------------+-----------------+-----------------"
+"+-----------------+\n"
+"Note: Np - propellers number; Nf - bow type; Na - stern type:\n"
+"- Nf   = 1 ... 5 (U-shaped, V-shaped, cylinder-shaped (drum), ram-conical, "
+"bulbous bow);\n"
+"- Na   = 1 ... 3 (U-shaped, V-shaped sections, cigar-shaped stern).\n"
+"9.5 Calculation resistance and power prediction by diagrams of Braun:\n"
+"- type of ships - highspeed ships are in preplaning regime;\n"
+"- Cb   = 0,290 ... 0,540;  L/B  = 3,50 ... 7,40;  B/T  = 3,10 ... 4,40;\n"
+"- FrV  = v/(g*V^0,3333)^0,5 = 0,8 ... 2,6;\n"
+"- Nser = 5 ;\n"
+"- Np   = 1 ;\n"
+"- Nf   = 1 ... 2 (U-shaped, V-shaped sections);\n"
+"- Na   = 1 ... 2 (U-shaped, V-shaped sections).\n"
+"9.6 Calculation resistance and power prediction by diagram of Neyman:\n"
+"- type of ships - tugs, trawlers and icebreakers;\n"
+"- Cp   = 0,500 ... 0,680;       B/T  =  2,4 ... 3,2;    Psi=L/V^0,333 = "
+"4,00 ... 7,20;\n"
+"- Fr   = 0,07 ... 0,45;\n"
+"- Nser = 6 ;\n"
+"- Nship= 1 ... 4 (1-tugs, 2-trawlers, 3 and 4-small warships);\n"
+"- Np   = 1 ;\n"
+"9.7 Calculation resistance and power prediction by a method of NIEWT "
+"(Russia):\n"
+"- type of ships - cargo vessels for inland and mixed navigation (river-"
+"sea);\n"
+"- Cp   = 0,800 ... 0,930;       L/B  = 4,00 ... 8,50;   B/T  = 3,70 ... "
+"14,0;\n"
+"- Fr   = 0,07 ... 0,25;\n"
+"- Nser = 7 ;\n"
+"- Np   = 1,2 ;\n"
+"9.8 Calculation resistance and power prediction by diagram of Volodin:\n"
+"- type of ships - highspeed round-bilge boats;\n"
+"9.9 Calculation resistance and power prediction by diagram of Nordstrom:\n"
+"- type of ships - highspeed round-bilge boats (14 models in 1936);\n"
+"- V = 10 ... 30 m^3;\n"
+"9.10  Calculation resistance and power prediction by diagrams of de Groot:\n"
+"- type of ships - highspeed round-bilge boats (31 models in 1951);\n"
+"9.11 Calculation resistance and power prediction by diagrams of SSPA:\n"
+"- type of ships - highspeed round-bilge boats (9 models in 1968);\n"
+"9.12 Calculation resistance and power prediction by diagrams of NPL:\n"
+"- type of ships - highspeed round-bilge boats (22 models in 1969 and 1976);\n"
+"9.13 Calculation resistance and power prediction by diagrams 64 series "
+"Taylor's basin:\n"
+"- type of ships - highspeed round-bilge boats (27 models in 1965);\n"
+"+---------+------------+---------------+---------------+---------------"
+"+--------------+------------+\n"
+"|Parameter|  Volodin   |   Nordstrom   |   de Groote   |     SSPA      |     "
+"NPL      |  64 series |\n"
+"+---------+------------+---------------+---------------+---------------"
+"+--------------+------------+\n"
+"|   Cb    | 0,4...0,7  | 0,373... 0,41 | 0,293... 0,56 |      0,4      |    "
+"0,397     | 0,35...0,55|\n"
+"|   Cp    |     -      | 0,576... 0,6  | 0,463...0,781 |      0,68     |    "
+"0,693     |     0,63   |\n"
+"|   L/B   |     -      | 4,83 ... 6,94 | 3,53 ...10,09 | 4,62 ... 8,20 | "
+"3,33 ...7,5  |8,45...18,26|\n"
+"|   B/T   |     -      | 3,70 ... 14,0 | 2,72 ... 6,58 | 3.0; 3.5; 4.0 | "
+"1,76 ... 6,87|2,0 ... 4,0 |\n"
+"|  Xc/Lpp |     -      |-1,79 ... 2,88%|-11,5 ... 3,09%|       -       |     "
+"-6,4%    |Xg/Lpp=6,56%|\n"
+"|   Psi   |     -      |       -       |       -       |    6; 7; 8    "
+"|       -      |     -      |\n"
+"|   SVLR  |     -      | 2,67 ... 2,70 |      2,75     |  2,9 ... 3,0  "
+"|       -      |     -      |\n"
+"|   a_f   |     -      | 15,1 ... 22,5°|       -       |  8,2 ... "
+"14,4°|       -      | 3,7... 7,8°|\n"
+"|   FrV   | 1,0...2,5  | 0,90 ... 2,00 |  0,8 ... 2,7  |  1,0 ... 2,0  |  "
+"0,5 ... 2,8 | 0,8... 3,0 |\n"
+"| Cfo(Re) |   Pr-Shl   |     Pr-Shl    |     Pr-Shl    |  by ITTC-57   |  by "
+"ITTC-57  |    Pr-Shl  |\n"
+"|   Nser  |     8      |       9       |      10       |       11      "
+"|       12     |      13    |\n"
+"|   Np    |     1      |       1       |       1       |        1      "
+"|        1     |       1    |\n"
+"+--------+------------+---------------+---------------+---------------"
+"+--------------+------------+\n"
+"where FrV = v/(g*V^0,3333)^0,5 ;   SVLR = S/(VL)^0,5 ;   Pr-Shl - formulae "
+"by Prandl-Schlichting\n"
+"9.14 Calculation resistance and power prediction by method of Doubrovsky:\n"
+"- type of ships - displacement catamarans;\n"
+"- Cb   = 0,3 ... 0,55 ;    C/L = 0,01 ... 0,15 ;   Psi  =  8,0 ... 18,0 ;\n"
+"- FrV  = 0,8 ... 2,2;\n"
+"- Nser = 14 ;\n"
+"- Np   = 1 ... 2 - number of hulls ;\n"
+"9.15 Calculation resistance and power prediction by method of Doubrovsky:\n"
+"- type of ships - displacement catamarans and trimarans;\n"
+"- Cb   = 0,35 ... 0,55 ;    S/Lwl = 0,15 ... 0,45 ;\n"
+"- Psi  =  8,0 ... 18,0 ;     A/Lwl = 0,0  ... 0,5  (for S/Lwl = 0,3);\n"
+"- Fr   = 0,25 ... 0,6;\n"
+"- Nser = 15 ;\n"
+"- Nh   = 1 ... 3 - number of hulls ;\n"
+"9.16 Calculation resistance and power prediction by methods NIEWT, GIEWT and "
+"LIWT (Russia):\n"
+"- type of ships - river cargoship, passenger, cargopassenger ships and "
+"tugs;\n"
+"- Cb   = 0,40 ... 0,85 ;  L/B   =   4,0 ... 9,0 ;\n"
+"- B/T  =  2,5 ... 7,5  ;  Lc/L  =   0,6 ... 0,85;\n"
+"- Fr   = 0,05 ... 0,35 ;\n"
+"- Nser = 16 ;\n"
+"- Nsh  = 1 ... 3 - type of ships (1-cargoship, 2- tugs, 3- passenger and "
+"cargopassenger ships);\n"
+"- Npr  = 1 ... 7 or 5 - number of ship prototype;\n"
+"Table. Characteristics of ship's prototype for inland and mixed navigation "
+"(river-sea)\n"
+"+-----+------+-------+-------+------+-----+------+-------+-------+-----"
+"+------+-------+-------+\n"
+"|Numb.| L/B  |  T/B  |  Cb   | Lc/L |Numb.| L/B  |  T/B  |  Cb   |Numb.| L/"
+"B  |  T/B  |  Cb   |\n"
+"+-----------------------------------+----------------------------"
+"+----------------------------+\n"
+"|           Cargo ships             |        River tugs          |Passenger "
+"and cargopassenger|\n"
+"+-----------------------------------+----------------------------"
+"+----------------------------+\n"
+"|  1  | 8.18 | 0.212 | 0.851 | 0.79 |  1  | 4.99 | 0.243 | 0.545 |  1  | "
+"7.75 | 0.190 | 0.575 |\n"
+"|  2  | 6.93 | 0.216 | 0.837 | 0.76 |  2  | 4.73 | 0.253 | 0.557 |  2  | "
+"8.10 | 0.198 | 0.710 |\n"
+"|  3  | 7.02 | 0.204 | 0.830 | 0.75 |  3  | 5.02 | 0.243 | 0.636 |  3  | "
+"6.60 | 0.202 | 0.573 |\n"
+"|  4  | 7.95 | 0.266 | 0.869 | 0.78 |  4  | 4.60 | 0.400 | 0.522 |  4  | "
+"5.72 | 0.249 | 0.465 |\n"
+"|  5  | 6.74 | 0.225 | 0.800 | 0.75 |  5  | 5.13 | 0.275 | 0.535 |  5  | "
+"4.73 | 0.202 | 0.581 |\n"
+"|  6  | 8.50 | 0.266 | 0.818 | 0.80 |  6  | 4.70 | 0.244 | 0.618 |     "
+"|      |       |       |\n"
+"|  7  | 6.11 | 0.184 | 0.788 | 0.76 |  7  | 4.04 | 0.135 | 0.528 |     "
+"|      |       |       |\n"
+"+-----------------------------------+----------------------------"
+"+----------------------------+\n"
+"9.17 Calculation resistance and power prediction by method Yeroshin:\n"
+"- type of ships - fishing ships (SFT, MFT, BFT);\n"
+"+---------+-----------------+------------------+-----------------+\n"
+"| Charact.|      SFT        |       MFT        |      BFT        |\n"
+"+---------+-----------------+------------------+-----------------+\n"
+"|  Cp     |  0,50 ... 0,72  |  0,55 ... 0,70   |       -         |\n"
+"|  Lpp/B  |   2,5 ... 3,5   |   3,5 ... 5,0    |       -         |\n"
+"|  B/T    |   2,6 ... 4,0   |   2,3 ... 3,2    |       -         |\n"
+"|  Cm     |  0,75 ... 0,92  |  0,65 ... 0,92   |       -         |\n"
+"|  lcb    | -0,05 ...-0,01  | -0,03 ... 0,01   |       -         |\n"
+"|  Fr     |   0,1 ... 0,5   |  0,21 ... 0,37   |       -         |\n"
+"+---------+-----------------+------------------+-----------------+\n"
+"NOTE: BFT series is NOT available now.\n"
+"- Nser = 17 ;\n"
+"- Nsh  = 1 ... 3 - type of fishing ship (1 - SFT, 2 - MFT, 3 - BFT);\n"
+"9.18 Calculation resistance and power prediction by prototype:\n"
+"- type of ships - highspeed sea ships w/o cylindrical body (Nm=1), tugs, "
+"icebreakers and fishing ships (Nm=2);\n"
+"- For Nm=1, Cp =  0,5 ... 0,85 ;  B/T =   2 ... 14 ;  Psi = L/V^0,333 = "
+"5 ... 11;  Fr = 0,25 ... 0,65 ;\n"
+"- For Nm=2, Cb = 0,45 ... 0,55 ;  L/B = 3,5 ... 5,5;  B/T =  2,0 ... "
+"3,5  ;        Fr = 0,10 ... 0,35 ;\n"
+"- Nser = 18 ;\n"
+"- Nm   = 1 ... 2  - method of calculation (1 - Geers, 2 - Doubrovin);\n"
+"- Npr  = 0 ... 20 - number of prototype in BD, if 0, then to input "
+"manually.\n"
+"9.19 Calculation resistance and power prediction by hard-chine catamarans:\n"
+"- type of ships - displacement hard-chine catamarans;\n"
+"- Cb   = 0,5 ... 0,6 ;   L/B = 10,0 ... 20,0 ;  B/T =  1,5 ... 2,5 ;  S/Lwl "
+"= 0,15 ... 0,55 ;\n"
+"- Psi  = 6,6 ... 12,6;\n"
+"- Fr   = 0,4 ... 1,5 ;\n"
+"- Nser = 19 ;\n"
+"- Nh   = 2 - number of hulls ;\n"
+"10. Calculation resistance and power prediction by experimental model's "
+"data:\n"
+"- type of ships - any displacement ships;\n"
+"- Nser = 0 ;\n"
+"NOTE: You must to set the coefficient of residual resistance Cr in function "
+"of Froude number Fr\n"
+"Cr=f(Fr), where is Fr=v/(g*L)^0,5."
+msgstr ""
+
+#: freestringsunit.rs_resistance_oortmer_note_p1
+msgid ""
+"1.Viscosity by default is for sea water with density 1025 kg/m^3 and "
+"temperature 15 °C.\n"
+"You can change the temperature and the density: Project->Project Settings-"
+">Hydrostatics"
+msgstr ""
+
+#: freestringsunit.rs_resistance_oortmer_note_p3
+msgctxt "freestringsunit.rs_resistance_oortmer_note_p3"
+msgid ""
+"3.Coefficient influence the after body form is from table:\n"
+"+-------------------------------------------------------"
+"+-------------------------+\n"
+"|                After body form                        |          "
+"Cstrn          |\n"
+"+-------------------------------------------------------"
+"+-------------------------+\n"
+"|              Normal sections                          |            "
+"0            |\n"
+"|              V-shaped sections                        |           "
+"-10           |\n"
+"|              U-shaped sections  (with Hogner stern)   |          5  "
+"( 10 )      |\n"
+"|              Barge type form                          |        -20  or "
+"-25      |\n"
+"+-------------------------------------------------------"
+"+-------------------------+"
+msgstr ""
+
+#: freestringsunit.rs_resistance_oortmer_note_p5
+msgid ""
+"5.Standart deviation of database for typical resistance van Oortmerssen's "
+"method:\n"
+"+-----------------------------+----------------------+\n"
+"|        Parameters           |      Limitations     |\n"
+"|-----------------------------+----------------------|\n"
+"| Length of water line,   Lwl |      8 ... 80 m      |\n"
+"| Displacement,          Disp |      5 ... 3000 m3   |\n"
+"| Length/Breadth,       Lwl/B |      3 ... 6.2       |\n"
+"| Breadth/Draft,          B/T |    1.9 ... 4.0       |\n"
+"| Prismatic coefficient,   Cp |   0.50 ... 0.73      |\n"
+"| Midship coefficient,     Cm |   0.70 ... 0.97      |\n"
+"| Long.center of buoyancy,LCB |  -7% L ... 2.8% L    |\n"
+"| Half entrance angle,     ie |     10 ... 46 degr   |\n"
+"| Speed/length,    V/sqrt(Lwl)|      0 ... 1.79      |\n"
+"| Froude number,           Fr |      0 ... 0.50      |\n"
+"+-----------------------------+----------------------+"
+msgstr ""
+
+#: freestringsunit.rs_resistance_oortmer_note_p6
+msgid ""
+"6.Standart deviation of database for typical resistance by Ridgeley-Nevitt "
+"1967:\n"
+"+-----------------------------+----------------------+\n"
+"|         Parameters          |      Limitations     |\n"
+"|-----------------------------+----------------------|\n"
+"| Length/Breadth,       Lwl/B |      4 ... 5.2       |\n"
+"| Prismatic coefficient,   Cp |   0.55 ... 0.70      |\n"
+"| Speed/length,    V/sqrt(Lwl)|   0.70 ... 1.50      |\n"
+"| Coefficient    V/(0.01*L)^3 |    200 ... 500       |\n"
+"+-----------------------------+----------------------+"
+msgstr ""
+
+#: freestringsunit.rs_resistance_oortmer_note_p7
+msgid ""
+"7.Standart deviation of database for typical resistance by UBC-1993 method:\n"
+"+-----------------------------+----------------------+\n"
+"|        Parameters           |      Limitations     |\n"
+"|-----------------------------+----------------------|\n"
+"| Length/Breadth,       Lwl/B |    2.6 ... 3.98      |\n"
+"| Breadth/Draft,          B/T |    2.0 ... 4.23      |\n"
+"| Prismatic coefficient,   Cp |   0.45 ... 0.61      |\n"
+"| Midship coefficient,     Cm |  0.747 ... 0.878     |\n"
+"| Coefficient      L/V^0.3333 |   3.00 ... 5.31      |\n"
+"| Froude number,           Fr |   0.20 ... 0.50      |\n"
+"+-----------------------------+----------------------+"
+msgstr ""
+
+#: freestringsunit.rs_resistance_prediction_for_sea_vessels__according_to_associate_prof__timoshenko
+msgid ""
+"Resistance prediction for sea vessels, according to Associate Prof. "
+"Timoshenko"
+msgstr ""
+
+#: freestringsunit.rs_resistance__effective_power__propulsion_factors_and_required_thrust
+msgid "Resistance, Effective Power, Propulsion Factors and Required Thrust"
+msgstr ""
+
+#: freestringsunit.rs_resistance__kn_
+msgctxt "freestringsunit.rs_resistance__kn_"
+msgid "Resistance [kN]"
+msgstr "Resistência [kN]"
+
+#: freestringsunit.rs_results_of_calculation_of_passport_diagram
+msgid "Results of calculation of passport diagram"
+msgstr ""
+
+#: freestringsunit.rs_results_of_calculation_optimal_propeller_for_engine_selection
+msgid "Results of calculation optimal propeller for engine selection"
+msgstr ""
+
+#: freestringsunit.rs_results_of_calculation_propeller_elements_for_selected_engine
+msgid "Results of calculation propeller elements for selected engine"
+msgstr ""
+
+#: freestringsunit.rs_results_of_optimisation_
+msgid "Results of optimisation:"
+msgstr ""
+
+#: freestringsunit.rs_reynolds_number_rn_______________________
+msgid "Reynolds Number RN                      ="
+msgstr ""
+
+#: freestringsunit.rs_righting_lever_longitudinal_form_stability_gz_lform
+msgid "Righting lever longitudinal form stability GZ_lform"
+msgstr ""
+
+#: freestringsunit.rs_righting_lever_longitudinal_static_stability_gz_psi
+msgid "Righting lever longitudinal static stability GZ_psi"
+msgstr ""
+
+#: freestringsunit.rs_righting_lever_transverse_form_stability___gz_tform
+msgid "Righting lever transverse form stability   GZ_tform"
+msgstr ""
+
+#: freestringsunit.rs_righting_lever_transverse_static_stability__gz_teta
+msgid "Righting lever transverse static stability  GZ_teta"
+msgstr ""
+
+#: freestringsunit.rs_robinson_john___performance_prediction_of_chine_and_round_bilge_hull_forms___international
+msgid ""
+"Robinson John, \"Performance Prediction of Chine and Round Bilge Hull "
+"Forms\", International"
+msgstr ""
+
+#: freestringsunit.rs_roger_h_compton___resistance_of_a_systemic_series_of_semiplaning_transom_stern_hulls__
+msgid ""
+"Roger H.Compton, \"Resistance of a Systemic Series of Semiplaning Transom-"
+"Stern Hulls\","
+msgstr ""
+
+#: freestringsunit.rs_rotate
+msgid "rotate"
+msgstr ""
+
+#: freestringsunit.rs_rotation_vector
+msgid "Rotation vector"
+msgstr ""
+
+#: freestringsunit.rs_roughness_coefficient_o10_3
+msgid "Roughness coefficient *10^3"
+msgstr ""
+
+#: freestringsunit.rs_rpm___
+msgid "RPM  ="
+msgstr ""
+
+#: freestringsunit.rs_rudder
+msgctxt "freestringsunit.rs_rudder"
+msgid "Rudder"
+msgstr "Leme"
+
+#: freestringsunit.rs_rudder_behind_skeg_stern
+msgctxt "freestringsunit.rs_rudder_behind_skeg_stern"
+msgid "Rudder behind skeg/stern"
+msgstr ""
+
+#: freestringsunit.rs_rudder_s_properties
+msgid "Rudder's properties"
+msgstr ""
+
+#: freestringsunit.rs_r_e_s_u_l_t_s___o_f___c_a_l_c_u_l_a_t_i_o_n
+msgid "R E S U L T S   O F   C A L C U L A T I O N"
+msgstr ""
+
+#: freestringsunit.rs_scale
+msgid "scale"
+msgstr ""
+
+#: freestringsunit.rs_scale_vector
+msgid "Scale vector"
+msgstr ""
+
+#: freestringsunit.rs_seconds
+msgid "seconds"
+msgstr ""
+
+#: freestringsunit.rs_sectional_areas
+msgid "Sectional areas"
+msgstr ""
+
+#: freestringsunit.rs_selected_items
+msgid "selected items"
+msgstr ""
+
+#: freestringsunit.rs_series_delft_for_sailing_yachts
+msgid "series Delft for sailing yachts"
+msgstr ""
+
+#: freestringsunit.rs_series_of_i_titov
+msgid "series of I.Titov"
+msgstr ""
+
+#: freestringsunit.rs_series_of_ksri_bihs
+msgid "series of KSRI-BIHS"
+msgstr ""
+
+#: freestringsunit.rs_series_of_m_zavadovsky
+msgid "series of M.Zavadovsky"
+msgstr ""
+
+#: freestringsunit.rs_series_of_troost
+msgid "series of Troost"
+msgstr ""
+
+#: freestringsunit.rs_series_of_v_mishkevich
+msgid "series of V.Mishkevich"
+msgstr ""
+
+#: freestringsunit.rs_series_of_v_turbal
+msgid "series of V.Turbal"
+msgstr ""
+
+#: freestringsunit.rs_series_of_zvezdkina
+msgid "series of Zvezdkina"
+msgstr ""
+
+#: freestringsunit.rs_set_crease_edges
+msgid "set crease edges"
+msgstr ""
+
+#: freestringsunit.rs_set_tolerance
+msgid "Set tolerance"
+msgstr ""
+
+#: freestringsunit.rs_shaft_brackets_area
+msgid "Shaft brackets area"
+msgstr ""
+
+#: freestringsunit.rs_shaf_effic_ogearbox_effic_
+msgid "Shaf effic.*Gearbox effic."
+msgstr ""
+
+#: freestringsunit.rs_ship_speed_vk__knots___________________
+msgid "Ship Speed Vk (knots)                 ="
+msgstr ""
+
+#: freestringsunit.rs_skeg
+msgctxt "freestringsunit.rs_skeg"
+msgid "Skeg"
+msgstr ""
+
+#: freestringsunit.rs_skeg_area
+msgid "Skeg area"
+msgstr ""
+
+#: freestringsunit.rs_sloa___length_overall__m__
+msgid "SLOA - Length overall [m];"
+msgstr ""
+
+#: freestringsunit.rs_some_input_datas_are_not_right___
+msgid "Some input datas are NOT right!!!"
+msgstr ""
+
+#: freestringsunit.rs_specified_engine_power__kw_
+msgctxt "freestringsunit.rs_specified_engine_power__kw_"
+msgid "Specified engine power [kW]"
+msgstr ""
+
+#: freestringsunit.rs_speed
+msgid "Speed"
+msgstr ""
+
+#: freestringsunit.rs_speed_ship__knots_
+msgid "Speed ship [knots]"
+msgstr ""
+
+#: freestringsunit.rs_speed_ship__kn_
+msgid "Speed ship [kn]"
+msgstr ""
+
+#: freestringsunit.rs_speed_step
+msgid "Speed step"
+msgstr ""
+
+#: freestringsunit.rs_speed__resistance_coefficients_and_frictional_resistance_rf_n__
+msgid "Speed, Resistance Coefficients and Frictional Resistance RF(N):"
+msgstr ""
+
+#: freestringsunit.rs_spray_strips_deadrise
+msgid "Spray strips deadrise"
+msgstr ""
+
+#: freestringsunit.rs_ssd_and_dsd_are_calculated_
+msgid "SSD and DSD are calculated!"
+msgstr ""
+
+#: freestringsunit.rs_ssd_and_dsd_calculation_for_input_d_and_zg
+msgid "SSD and DSD calculation for input D and Zg"
+msgstr ""
+
+#: freestringsunit.rs_ssd_calculation_for_imported_d_and_zg
+msgid "SSD calculation for imported D and Zg"
+msgstr ""
+
+#: freestringsunit.rs_stabiliser_fins_area
+msgid "Stabiliser fins area"
+msgstr ""
+
+#: freestringsunit.rs_stability_calculation_according_to_the_rules_of_the_river_register_of_shipping_of_ukraine_
+msgid ""
+"Stability calculation according to the rules of the River Register of "
+"Shipping of Ukraine:"
+msgstr ""
+
+#: freestringsunit.rs_stability_calculation_results
+msgid "Stability calculation results"
+msgstr ""
+
+#: freestringsunit.rs_stability_characteristics
+msgid "Stability characteristics"
+msgstr ""
+
+#: freestringsunit.rs_started_speed__knots__m_s__
+msgid "Started speed [knots (m/s)]"
+msgstr ""
+
+#: freestringsunit.rs_start_speed
+msgctxt "freestringsunit.rs_start_speed"
+msgid "Start speed"
+msgstr ""
+
+#: freestringsunit.rs_static_and_dynamic_stability_diagrams__ssd___dsd_
+msgid "Static and Dynamic Stability Diagrams (SSD & DSD)"
+msgstr ""
+
+#: freestringsunit.rs_station
+msgid "Station"
+msgstr "Baliza"
+
+#: freestringsunit.rs_stations
+msgctxt "freestringsunit.rs_stations"
+msgid "Stations"
+msgstr "Balizas"
+
+#: freestringsunit.rs_step_of_propeller_diameter_is_very_big_
+msgid "Step of propeller diameter is very big!"
+msgstr ""
+
+#: freestringsunit.rs_step_on_diameter__m_
+msgid "Step on diameter [m]"
+msgstr ""
+
+#: freestringsunit.rs_stern_type______________________________
+msgid "Stern Type                             ="
+msgstr ""
+
+#: freestringsunit.rs_strake
+msgid "Strake"
+msgstr ""
+
+#: freestringsunit.rs_strut_bossing_area
+msgid "Strut bossing area"
+msgstr ""
+
+#: freestringsunit.rs_submerged_transom_area_ratio
+msgid "Submerged transom area ratio"
+msgstr ""
+
+#: freestringsunit.rs_summary_inertia_moment_of_engine__kgom2_
+msgid "Summary inertia moment of engine [kg*m2]"
+msgstr ""
+
+#: freestringsunit.rs_t
+msgid "t"
+msgstr ""
+
+#: freestringsunit.rs_table
+msgid "Table"
+msgstr ""
+
+#: freestringsunit.rs_task_do_not_solve_with_this_data_
+msgid "Task do not solve with this data!"
+msgstr ""
+
+#: freestringsunit.rs_test_stability_coefficient
+msgid "Test stability coefficient"
+msgstr ""
+
+#: freestringsunit.rs_there_is_already_one_backgroundimage_assigned_to_this_view_
+msgid "There is already one backgroundimage assigned to this view."
+msgstr ""
+
+#: freestringsunit.rs_there_is_no_submersion
+msgid "There is no submersion"
+msgstr ""
+
+#: freestringsunit.rs_the_current_fileversion_is_version
+msgid "The current fileversion is version"
+msgstr ""
+
+#: freestringsunit.rs_the_current_model_has_been_changed_
+msgid "The current model has been changed!"
+msgstr ""
+
+#: freestringsunit.rs_the_current_settings_will_be_lost
+msgid "The current settings will be lost"
+msgstr ""
+
+#: freestringsunit.rs_the_file_contains_no_bspline_surfaces
+msgid "The file contains no BSpline surfaces"
+msgstr ""
+
+#: freestringsunit.rs_the_following_items_were_corrected
+msgid "The following items were corrected"
+msgstr ""
+
+#: freestringsunit.rs_the_following_layer_properties_are_calculated_for_both_sides_of_the_ship
+msgid ""
+"The following layer properties are calculated for both sides of the ship"
+msgstr ""
+
+#: freestringsunit.rs_the_model_already_contains_markers__do_you_want_to_delete_those_
+msgid "The model already contains markers. Do you want to delete those?"
+msgstr ""
+
+#: freestringsunit.rs_the_model_contains_a_total_of
+msgid "The model contains a total of"
+msgstr ""
+
+#: freestringsunit.rs_the_selection_contains_locked_points_that_will_not_be_affected_by_this_operation
+msgid ""
+"The selection contains locked points that will not be affected by this "
+"operation"
+msgstr ""
+
+#: freestringsunit.rs_the_vessel_does_not_correspond_to_any_category_of_navigation____
+msgid "The vessel does not correspond to any category of navigation !!!"
+msgstr ""
+
+#: freestringsunit.rs_thickness
+msgctxt "freestringsunit.rs_thickness"
+msgid "Thickness"
+msgstr ""
+
+#: freestringsunit.rs_this_calculation_method_is_here___series_by_oct_5_0181_75_and_other_methods____
+msgid ""
+"This calculation method is here: \"Series by OCT 5.0181-75 and other "
+"methods...\""
+msgstr ""
+
+#: freestringsunit.rs_this_file_was_created_with_a_later_version_of_free_ship_
+msgid "This file was created with a later version of FREE!ship!"
+msgstr ""
+
+#: freestringsunit.rs_this_is_diagram_of_propeller_access_in_pro_version_only
+msgid "This is diagram of propeller access in Pro version only"
+msgstr ""
+
+#: freestringsunit.rs_this_is_not_a_valid_free_ship_file_
+msgid "This is not a valid FREE!ship file!"
+msgstr ""
+
+#: freestringsunit.rs_this_is_not_a_valid_free_ship_part_file_
+msgid "This is not a valid FREE!ship part file!"
+msgstr ""
+
+#: freestringsunit.rs_this_is_not_a_valid_vrml_1_0_file
+msgid "This is not a valid VRML 1.0 file"
+msgstr ""
+
+#: freestringsunit.rs_this_is_not_a_valid_vrml_2_0_file
+msgid "This is not a valid VRML 2.0 file"
+msgstr ""
+
+#: freestringsunit.rs_this_is_propeller_not_a_strong_in_non_uniform_flow_
+msgid "This is propeller not a strong in non-uniform flow!"
+msgstr ""
+
+#: freestringsunit.rs_this_is_propeller_not_a_strong_in_uniform_flow_
+msgid "This is propeller not a strong in uniform flow!"
+msgstr ""
+
+#: freestringsunit.rs_this_is_series_have_not_datas_of_prototype_in_bd_now___
+msgid "This is series have NOT datas of prototype in BD now!!!"
+msgstr ""
+
+#: freestringsunit.rs_this_is_series_not_available_now___
+msgid "This is series NOT available now!!!"
+msgstr ""
+
+#: freestringsunit.rs_this_is_version_of_program_work_with_metric_system_units_only
+msgid "This is version of program work with metric system units only"
+msgstr ""
+
+#: freestringsunit.rs_this_model_contains_locked_points_that_will_be_modified_by_this_operation
+msgid ""
+"This model contains locked points that will be modified by this operation"
+msgstr ""
+
+#: freestringsunit.rs_thrust_coefficient_and_torque__kt__10okq
+msgid "Thrust coefficient and torque: KT; 10*KQ"
+msgstr ""
+
+#: freestringsunit.rs_thrust_coefficient_kt____________________
+msgid "Thrust Coefficient KT                   ="
+msgstr ""
+
+#: freestringsunit.rs_thrust_deduction_fraction_t
+msgid "Thrust deduction fraction t"
+msgstr ""
+
+#: freestringsunit.rs_thrust__kn___torque__knom_
+msgid "Thrust [kN]; Torque [kN*m]"
+msgstr ""
+
+#: freestringsunit.rs_time
+msgctxt "freestringsunit.rs_time"
+msgid "Time"
+msgstr ""
+
+#: freestringsunit.rs_time__sec_
+msgid "Time [sec]"
+msgstr ""
+
+#: freestringsunit.rs_tonnes
+msgid "tonnes"
+msgstr ""
+
+#: freestringsunit.rs_tonnes_and_z_cog__
+msgid "tonnes and Z CoG ="
+msgstr ""
+
+#: freestringsunit.rs_tons
+msgid "tons"
+msgstr ""
+
+#: freestringsunit.rs_torque_coefficient_kq____________________
+msgid "Torque Coefficient KQ                   ="
+msgstr ""
+
+#: freestringsunit.rs_torque_yaw__knom_
+msgid "Torque yaw [kN*m]"
+msgstr ""
+
+#: freestringsunit.rs_total
+msgid "Total"
+msgstr ""
+
+#: freestringsunit.rs_total_beam_of_submerged_body
+msgid "Total beam of submerged body"
+msgstr ""
+
+#: freestringsunit.rs_total_draft
+msgctxt "freestringsunit.rs_total_draft"
+msgid "Total draft"
+msgstr ""
+
+#: freestringsunit.rs_total_length_of_submerged_body
+msgid "Total length of submerged body"
+msgstr ""
+
+#: freestringsunit.rs_towing_resistance_as_function_of_a_speed
+msgid "Towing resistance as function of a speed"
+msgstr ""
+
+#: freestringsunit.rs_transformation_succeeded_after
+msgid "Transformation succeeded after"
+msgstr ""
+
+#: freestringsunit.rs_translation_author
+msgid "Translation: <Your name>"
+msgstr ""
+
+#: freestringsunit.rs_translation_vector
+msgid "Translation vector"
+msgstr ""
+
+#: freestringsunit.rs_transom_area
+msgid "Transom area"
+msgstr ""
+
+#: freestringsunit.rs_transom_deadrise
+msgid "Transom deadrise"
+msgstr ""
+
+#: freestringsunit.rs_transom_immersed_area__m_2______________
+msgid "Transom Immersed Area (m^2)            ="
+msgstr ""
+
+#: freestringsunit.rs_transormation_failed
+msgid "Transormation failed"
+msgstr ""
+
+#: freestringsunit.rs_transparency_tolerance
+msgid "Transparency tolerance"
+msgstr ""
+
+#: freestringsunit.rs_transverse_center_of_buoyancy
+msgid "Transverse center of buoyancy"
+msgstr ""
+
+#: freestringsunit.rs_transverse_metacentric_radius
+msgid "Transverse metacentric radius"
+msgstr ""
+
+#: freestringsunit.rs_transverse_moment_of_inertia
+msgid "Transverse moment of inertia"
+msgstr ""
+
+#: freestringsunit.rs_transverse_moment_of_stability_for_heel_angle_30_
+msgid "Transverse moment of stability for heel angle=30°"
+msgstr ""
+
+#: freestringsunit.rs_transverse_projected_wind_area_______at__
+msgid "TRANSVERSE PROJECTED WIND AREA ..... AT :"
+msgstr ""
+
+#: freestringsunit.rs_transverse_righting_lever_for_heeling_angle_30_
+msgid "Transverse righting lever for heeling angle=30°"
+msgstr ""
+
+#: freestringsunit.rs_trim_angle_increment
+msgid "Trim angle increment"
+msgstr ""
+
+#: freestringsunit.rs_trim_angle_tau__degr_
+msgid "Trim angle Tau [degr]"
+msgstr ""
+
+#: freestringsunit.rs_type_and_series_of_propeller
+msgid "Type and series of propeller"
+msgstr ""
+
+#: freestringsunit.rs_type_of_a_ship_or_number_of_masts_____m__
+msgid "TYPE OF A SHIP OR NUMBER OF MASTS.... M :"
+msgstr ""
+
+#: freestringsunit.rs_type_of_a_ship__1_15_
+msgid "Type of a ship (1-15)"
+msgstr ""
+
+#: freestringsunit.rs_type_of_fishing_ship__nsh___1___3_
+msgid "Type of fishing ship (Nsh = 1...3)"
+msgstr ""
+
+#: freestringsunit.rs_type_of_river_ship___nsh___1___3_
+msgid "Type of river ship  (Nsh = 1...3)"
+msgstr ""
+
+#: freestringsunit.rs_type_of_ship______nship___1___4_
+msgid "Type of ship     (Nship = 1...4)"
+msgstr ""
+
+#: freestringsunit.rs_t_m_3
+msgctxt "freestringsunit.rs_t_m_3"
+msgid "t/m^3"
+msgstr ""
+
+#: freestringsunit.rs_t___t________t_____t_______t_______t_______t_______t_______t_______t_______t_______t
+msgid ""
+"+---+--------+-----+-------+-------+-------+-------+-------+-------+-------"
+"+-------+"
+msgstr ""
+
+#: freestringsunit.rs_t___t________t_____t_______________________________________________________________t
+msgid ""
+"+---+--------+-----"
+"+---------------------------------------------------------------+"
+msgstr ""
+
+#: freestringsunit.rs_t_______t_______t_______t_________t_________t_________t_________t
+msgid "+-------+-------+-------+---------+---------+---------+---------+"
+msgstr ""
+
+#: freestringsunit.rs_t________t________t________t________t________t________t________t________t________t
+msgid ""
+"+--------+--------+--------+--------+--------+--------+--------+--------"
+"+--------+"
+msgstr ""
+
+#: freestringsunit.rs_t__________t________t________t________t________t________t
+msgid "+----------+--------+--------+--------+--------+--------+"
+msgstr ""
+
+#: freestringsunit.rs_t__________t________t________t________t________t________t________t
+msgid "+----------+--------+--------+--------+--------+--------+--------+"
+msgstr ""
+
+#: freestringsunit.rs_t__________t________t____________________________________________t
+msgid "+----------+--------+--------------------------------------------+"
+msgstr ""
+
+#: freestringsunit.rs_t__________t____________________________________________t
+msgid "+----------+--------------------------------------------+"
+msgstr ""
+
+#: freestringsunit.rs_t_____________t___________________t____________________t___________________t
+msgid ""
+"+-------------+-------------------+--------------------+-------------------+"
+msgstr ""
+
+#: freestringsunit.rs_t_____________t________________________________________t___________________t
+msgid ""
+"+-------------+----------------------------------------+-------------------+"
+msgstr ""
+
+#: freestringsunit.rs_t_________________t______________t_____________t
+msgid "+-----------------+--------------+-------------+"
+msgstr ""
+
+#: freestringsunit.rs_t______________________________________________t
+msgid "+----------------------------------------------+"
+msgstr ""
+
+#: freestringsunit.rs_unable_to_create_a_backup_file_
+msgid "Unable to create a backup file!"
+msgstr ""
+
+#: freestringsunit.rs_unable_to_create_file_
+msgid "Unable to create file!"
+msgstr ""
+
+#: freestringsunit.rs_unable_to_open_file_
+msgid "Unable to open file!"
+msgstr ""
+
+#: freestringsunit.rs_undo
+msgctxt "freestringsunit.rs_undo"
+msgid "Undo"
+msgstr ""
+
+#: freestringsunit.rs_undo_memory
+msgid "Undo memory"
+msgstr ""
+
+#: freestringsunit.rs_unexpected_end_of_file_
+msgid "Unexpected end of file!"
+msgstr ""
+
+#: freestringsunit.rs_unknown_fileversion
+msgid "Unknown fileversion"
+msgstr ""
+
+#: freestringsunit.rs_unknown_intersection_type
+msgid "Unknown intersection type"
+msgstr ""
+
+#: freestringsunit.rs_unknown_point_in_mirror_command_
+msgid "Unknown point in mirror command!"
+msgstr ""
+
+#: freestringsunit.rs_unlock_all_points
+msgid "unlock all points"
+msgstr ""
+
+#: freestringsunit.rs_unlock_points
+msgid "unlock points"
+msgstr ""
+
+#: freestringsunit.rs_unsatisfactory_stability__because_weather_criteria_k__
+msgid "Unsatisfactory stability, because Weather criteria K ="
+msgstr ""
+
+#: freestringsunit.rs_using_of_spray_strips_with_cg__0_5_inappropriate___
+msgid "Using of spray strips with Cg> 0.5 inappropriate..."
+msgstr ""
+
+#: freestringsunit.rs_value_must_be_between
+msgid "Value must be between"
+msgstr ""
+
+#: freestringsunit.rs_version
+msgctxt "freestringsunit.rs_version"
+msgid "Version"
+msgstr ""
+
+#: freestringsunit.rs_vertical_center_of_bulb_area__m_________
+msgid "Vertical Center of Bulb Area (m)       ="
+msgstr ""
+
+#: freestringsunit.rs_vertical_center_of_buoyancy
+msgid "Vertical center of buoyancy"
+msgstr ""
+
+#: freestringsunit.rs_vertical_center_of_effort
+msgid "Vertical center of effort"
+msgstr ""
+
+#: freestringsunit.rs_vertical_of_transverse_metacenter
+msgid "Vertical of transverse metacenter"
+msgstr ""
+
+#: freestringsunit.rs_vert__prismatic_coefficient
+msgid "Vert. prismatic coefficient"
+msgstr ""
+
+#: freestringsunit.rs_volume_of_bulb
+msgid "Volume of bulb"
+msgstr ""
+
+#: freestringsunit.rs_volume_of_rudder_keel
+msgid "Volume of rudder/keel"
+msgstr ""
+
+#: freestringsunit.rs_volume_properties
+msgid "Volume properties"
+msgstr ""
+
+#: freestringsunit.rs_vp____
+msgid "Vp   ="
+msgstr ""
+
+#: freestringsunit.rs_v_kts____rfok1______rapp______rw_________rb_______rtr_______ra_______rair
+msgid ""
+"V(kts)   RF*K1      RAPP      RW         RB       RTR       RA       RAIR"
+msgstr ""
+
+#: freestringsunit.rs_v_kts____rt_n______pe_kw_______w________t_____req_thr_n_____etah______etar
+msgid ""
+"V(kts)   RT(N)     PE(kW)      w        t     REQ.THR(N)    EtaH      EtaR"
+msgstr ""
+
+#: freestringsunit.rs_v_kts_____v_m_s_______fn_____slratio_____cf________cr________ca_______rf
+msgid ""
+"V(kts)    V(m/s)      FN     SLRATIO     CF        CR        CA       RF"
+msgstr ""
+
+#: freestringsunit.rs_w
+msgid "W"
+msgstr ""
+
+#: freestringsunit.rs_wageningen_b_screw_series_propeller_preliminary_design
+msgid "Wageningen B-Screw Series Propeller Preliminary Design"
+msgstr ""
+
+#: freestringsunit.rs_waited_speed_ship__knots_
+msgid "Waited speed ship [knots]"
+msgstr ""
+
+#: freestringsunit.rs_wake_fraction_wt
+msgid "Wake fraction Wt"
+msgstr ""
+
+#: freestringsunit.rs_wake_fraction_w________________________
+msgid "Wake Fraction w                       ="
+msgstr ""
+
+#: freestringsunit.rs_warning____very_big_trim__tf_ta_
+msgid "Warning!!! Very big trim (Tf-Ta)"
+msgstr ""
+
+#: freestringsunit.rs_waterline
+msgid "Waterline"
+msgstr "Linha d'água (Flutuação)"
+
+#: freestringsunit.rs_waterlines
+msgctxt "freestringsunit.rs_waterlines"
+msgid "Waterlines"
+msgstr ""
+
+#: freestringsunit.rs_waterplane_area
+msgctxt "freestringsunit.rs_waterplane_area"
+msgid "Waterplane area"
+msgstr ""
+
+#: freestringsunit.rs_waterplane_center_of_floatation
+msgid "Waterplane center of floatation"
+msgstr ""
+
+#: freestringsunit.rs_waterplane_coefficient
+msgid "Waterplane coefficient"
+msgstr "Coeficiente de Área de Flutuação"
+
+#: freestringsunit.rs_waterplane_coefficient_on_lwl______cwp__
+msgid "Waterplane Coefficient on LWL      CWP ="
+msgstr ""
+
+#: freestringsunit.rs_waterplane_properties
+msgid "Waterplane properties"
+msgstr ""
+
+#: freestringsunit.rs_water_density
+msgctxt "freestringsunit.rs_water_density"
+msgid "Water density"
+msgstr ""
+
+#: freestringsunit.rs_water_density_rho__kg_m_3______________
+msgid "Water Density Rho (kg/m^3)            ="
+msgstr ""
+
+#: freestringsunit.rs_water_density__kg_m3_
+msgid "Water density [kg/m3]"
+msgstr ""
+
+#: freestringsunit.rs_water_density__kg_m_3___________________
+msgid "Water Density (kg/m^3)                 ="
+msgstr ""
+
+#: freestringsunit.rs_water_type_____________________________
+msgid "Water Type                            ="
+msgstr ""
+
+#: freestringsunit.rs_water_type______________________________
+msgid "Water Type                             ="
+msgstr ""
+
+#: freestringsunit.rs_water_viscosity
+msgid "Water viscosity"
+msgstr ""
+
+#: freestringsunit.rs_weather_criteria_k
+msgid "Weather criteria K"
+msgstr ""
+
+#: freestringsunit.rs_weight
+msgctxt "freestringsunit.rs_weight"
+msgid "Weight"
+msgstr ""
+
+#: freestringsunit.rs_weight__tonnes____
+msgid "Weight, tonnes   ="
+msgstr ""
+
+#: freestringsunit.rs_wetted_area
+msgctxt "freestringsunit.rs_wetted_area"
+msgid "Wetted area"
+msgstr "Área molhada"
+
+#: freestringsunit.rs_wetted_area_by_holtrop_formulae_is_not_right__because_cwp_0____
+msgid "Wetted area by Holtrop formulae is NOT right, because Cwp=0 !!!"
+msgstr ""
+
+#: freestringsunit.rs_wetted_surface_area
+msgctxt "freestringsunit.rs_wetted_surface_area"
+msgid "Wetted surface area"
+msgstr "Área de superfície molhada"
+
+#: freestringsunit.rs_wetted_surface__m_2_____________________
+msgid "Wetted Surface (m^2)                   ="
+msgstr "Superfície Molhada (m^2)                 ="
+
+#: freestringsunit.rs_wind_area_righting_lever
+msgid "Wind area righting lever"
+msgstr ""
+
+#: freestringsunit.rs_with_bulb
+msgid "with bulb"
+msgstr ""
+
+#: freestringsunit.rs_x_coordinate
+msgid "X coordinate"
+msgstr ""
+
+#: freestringsunit.rs_x_coordinate_of_wind_area_cog
+msgid "X coordinate of wind area CoG"
+msgstr ""
+
+#: freestringsunit.rs_x_of_cog
+msgid "X of CoG"
+msgstr ""
+
+#: freestringsunit.rs_yachtres__resistance_prediction_for_sailing_yachts__according_to_prof__gerritsma
+msgid ""
+"YachtRes, resistance prediction for sailing yachts, according to Prof. "
+"Gerritsma"
+msgstr ""
+
+#: freestringsunit.rs_you_have_to_set_the_mainparticulars_first_
+msgid "You have to set the mainparticulars first!"
+msgstr ""
+
+#: freestringsunit.rs_you_must_to_increase_ae_ao__may_be_cavitation_and_or_destruction_of_propeller_
+msgid ""
+"You must to increase Ae/Ao! May be cavitation and/or destruction of "
+"propeller."
+msgstr ""
+
+#: freestringsunit.rs_you_must_to_increase_number_of_blades_until
+msgid "You must to increase number of blades until"
+msgstr ""
+
+#: freestringsunit.rs_you_need_to_select_at_least_3_controlpoints_to_create_a_new_controlface
+msgid "You need to select at least 3 controlpoints to create a new controlface"
+msgstr ""
+
+#: freestringsunit.rs_y_coordinate
+msgid "Y coordinate"
+msgstr ""
+
+#: freestringsunit.rs_y_coordinate_of_dwl_area_cog
+msgid "Y coordinate of DWL area CoG"
+msgstr ""
+
+#: freestringsunit.rs_zero_thrust_advance_coeff__jp_t0__
+msgid "Zero thrust advance coeff. Jp_T0 ="
+msgstr ""
+
+#: freestringsunit.rs_zero_torque_advance_coeff__jp_q0__
+msgid "Zero torque advance coeff. Jp_Q0 ="
+msgstr ""
+
+#: freestringsunit.rs_z_coordinate
+msgid "Z coordinate"
+msgstr ""
+
+#: freestringsunit.rs_z_coordinate_of_cog
+msgid "Z coordinate of CoG"
+msgstr ""
+
+#: freestringsunit.rs_z_coordinate_of_wind_area_cog
+msgid "Z coordinate of wind area CoG"
+msgstr ""
+
+#: freestringsunit.rs__degr_________________________________________________________________
+msgid "(degr)          (-)      (-)         (-)      (-)         (-)      (-)"
+msgstr ""
+
+#: freestringsunit.rs___by_curve_of_propeller_optimal_frequency
+msgid "- by curve of propeller optimal frequency"
+msgstr ""
+
+#: freestringsunit.rs___calculated
+msgid "- calculated"
+msgstr ""
+
+#: freestringsunit.rs___for_selection_of_propeller_diagram
+msgid "- for selection of propeller diagram"
+msgstr ""
+
+#: freestringsunit.rs___negative_accelerated_moving
+msgid "- negative accelerated moving"
+msgstr ""
+
+#: freestringsunit.rs___positive_accelerated_moving
+msgid "- positive accelerated moving"
+msgstr ""
+
+#: freestringsunit.rs___without_shipwaves_and_depth_water
+msgid "- without shipwaves and depth water"
+msgstr ""
+
+#: freestringsunit.rs___with_shipwaves_and_depth_water_for
+msgid "- with shipwaves and depth water for"
+msgstr ""
+
+#: freestringsunit.rs__________form____appendage___wave_______bulb____transom_correlation_air_drag
+msgid ""
+"         Form    Appendage   Wave       Bulb    Transom Correlation Air Drag"
+msgstr ""
+
+#: freestringsunit.rs__________________long_force____________lat_force__________yaw_moment____
+msgid ""
+".................LONG FORCE............LAT FORCE..........YAW MOMENT...."
+msgstr ""
+
+#: freestringsunit.rs_______________________________________________________________________________________________
+msgid "----------------------------------------------------------------------------------------------"
+msgstr ""
+
+#: freestringutils.rsallfiles
+msgctxt "freestringutils.rsallfiles"
+msgid "All files"
+msgstr ""
+
+#: freestringutils.rsbitmapfiles
+msgid "Bitmap files"
+msgstr ""
+
+#: freestringutils.rsimagefiles
+msgid "Image files"
+msgstr ""
+
+#: freestringutils.rsjpegfiles
+msgid "JPEG files"
+msgstr ""
+
+#: freeupdatedlg.rscurrentversion
+msgid "Current Version"
+msgstr ""
+
+#: freeupdatedlg.rsknownsslexception
+#, object-pascal-format
+msgid ""
+"Exception class: %s Message: %s\n"
+"Possibly missing OpenSSL DLLs: libeay32.dll, ssleay32.dll.\n"
+"You can download these from http://wiki.overbyte.eu/wiki/index.php/"
+"ICS_Download#Download_OpenSSL_Binaries_.28required_for_SSL-"
+"enabled_components.29\n"
+"Please use latest binaries for SSL v1.0 \"OpenSSL Binaries Win-64 v1.0.*\".\n"
+"Place libeay32.dll and ssleay32.dll into directory where FreeShip.exe is "
+"installed.\n"
+"Usually it is C:\\Program Files\\FreeShip\\.\n"
+"FreeShip is currently compatible with libssl v1.0 only.\n"
+"You have to check for updates traditional way at Download page.\n"
+"Click link below."
+msgstr ""
+
+#: main.rsexitconfirmation
+msgid ""
+"The current model has been changed\n"
+"Are you sure you want to exit?"
+msgstr ""
+
+#: mdipanel.rsclose
+msgctxt "mdipanel.rsclose"
+msgid "Close"
+msgstr ""
+
+#: mdipanel.rsmaximize
+msgid "Maximize"
+msgstr ""
+
+#: mdipanel.rsminimize
+msgid "Minimize"
+msgstr ""
+
+#: mdipanel.rsrestore
+msgid "Restore"
+msgstr ""
+
+#: tfreecontrolpointform.caption
+msgctxt "tfreecontrolpointform.caption"
+msgid " "
+msgstr ""
+
+#: tfreecontrolpointform.checkboxanchorhard.caption
+msgctxt "tfreecontrolpointform.checkboxanchorhard.caption"
+msgid "Hard"
+msgstr ""
+
+#: tfreecontrolpointform.checkboxcorner.caption
+msgid "Corner"
+msgstr ""
+
+#: tfreecontrolpointform.groupboxanchorconstraint.caption
+msgid "Anchor point"
+msgstr ""
+
+#: tfreecontrolpointform.groupboxlinearconstraint.caption
+msgid "Linear constraint"
+msgstr ""
+
+#: tfreecontrolpointform.label1.caption
+msgid "Label1"
+msgstr ""
+
+#: tfreecontrolpointform.label2.caption
+msgctxt "tfreecontrolpointform.label2.caption"
+msgid "Label2"
+msgstr ""
+
+#: tfreecontrolpointform.label3.caption
+msgid "Label3"
+msgstr ""
+
+#: tfreecontrolpointform.label4.caption
+msgctxt "tfreecontrolpointform.label4.caption"
+msgid "Distance"
+msgstr ""
+
+#: tfreecontrolpointform.label5.caption
+msgctxt "tfreecontrolpointform.label5.caption"
+msgid "Angle"
+msgstr ""
+
+#: tfreecontrolpointform.labelax.caption
+msgctxt "tfreecontrolpointform.labelax.caption"
+msgid "º"
+msgstr ""
+
+#: tfreecontrolpointform.labelay.caption
+msgctxt "tfreecontrolpointform.labelay.caption"
+msgid "º"
+msgstr ""
+
+#: tfreecontrolpointform.labelaz.caption
+msgctxt "tfreecontrolpointform.labelaz.caption"
+msgid "º"
+msgstr ""
+
+#: tfreecontrolpointform.labelname.caption
+msgctxt "tfreecontrolpointform.labelname.caption"
+msgid "Name"
+msgstr ""
+
+#: tfreecontrolpointform.labelx.caption
+msgid "X-coord."
+msgstr ""
+
+#: tfreecontrolpointform.labely.caption
+msgid "Y-coord."
+msgstr ""
+
+#: tfreecontrolpointform.labelz.caption
+msgid "Z-coord."
+msgstr ""
+
+#: tfreecontrolpointform.speedbuttonremoveanchorpoint.caption
+msgctxt "tfreecontrolpointform.speedbuttonremoveanchorpoint.caption"
+msgid "x"
+msgstr ""
+
+#: tfreecontrolpointform.speedbuttonremoveanchorpoint.hint
+msgid "Remove anchoring"
+msgstr ""
+
+#: tfreecontrolpointform.speedbuttonremovelinearconstraint.caption
+msgctxt "tfreecontrolpointform.speedbuttonremovelinearconstraint.caption"
+msgid "x"
+msgstr ""
+
+#: tfreecontrolpointform.speedbuttonremovelinearconstraint.hint
+msgid "Remove linear constraint"
+msgstr ""
+
+#: tfreefilepreviewdialog.actionrefresh.caption
+msgid "ActionRefresh"
+msgstr ""
+
+#: tfreefilepreviewdialog.bitbtncancel.caption
+msgctxt "tfreefilepreviewdialog.bitbtncancel.caption"
+msgid "Cancel"
+msgstr ""
+
+#: tfreefilepreviewdialog.bitbtnopen.caption
+msgctxt "tfreefilepreviewdialog.bitbtnopen.caption"
+msgid "Open"
+msgstr ""
+
+#: tfreefilepreviewdialog.comboboxdir.text
+msgid "."
+msgstr ""
+
+#: tfreefilepreviewdialog.editname.text
+msgid "EditName"
+msgstr ""
+
+#: tfreefilepreviewdialog.fitsize.caption
+msgid "Fit Size"
+msgstr ""
+
+#: tfreefilepreviewdialog.fullsize.caption
+msgid "Full Size"
+msgstr ""
+
+#: tfreefilepreviewdialog.labellocation.caption
+msgid "Location:"
+msgstr ""
+
+#: tfreefilepreviewdialog.labelname.caption
+msgid "Name:"
+msgstr ""
+
+#: tfreefilepreviewdialog.placesmenuitemdelete.caption
+msgctxt "tfreefilepreviewdialog.placesmenuitemdelete.caption"
+msgid "Delete"
+msgstr ""
+
+#: tfreefilepreviewdialog.placesmenuitemrename.caption
+msgctxt "tfreefilepreviewdialog.placesmenuitemrename.caption"
+msgid "Rename"
+msgstr ""
+
+#: tfreefilepreviewdialog.properties.caption
+msgctxt "tfreefilepreviewdialog.properties.caption"
+msgid "Properties"
+msgstr ""
+
+#: tfreefilepreviewdialog.scrollboxpreview.hint
+msgctxt "tfreefilepreviewdialog.scrollboxpreview.hint"
+msgid "DblClick to full size"
+msgstr ""
+
+#: tfreefilepreviewdialog.shelllistviewitemdelete.caption
+msgctxt "tfreefilepreviewdialog.shelllistviewitemdelete.caption"
+msgid "Delete"
+msgstr ""
+
+#: tfreefilepreviewdialog.shelllistviewitemnewfolder.caption
+msgid "New Folder"
+msgstr ""
+
+#: tfreefilepreviewdialog.shelllistviewitemrename.caption
+msgctxt "tfreefilepreviewdialog.shelllistviewitemrename.caption"
+msgid "Rename"
+msgstr ""
+
+#: tfreefilepreviewdialog.speedbuttonaddplace.caption
+msgctxt "tfreefilepreviewdialog.speedbuttonaddplace.caption"
+msgid "+"
+msgstr ""
+
+#: tfreefilepreviewdialog.speedbuttonaddplace.hint
+msgid "Add place"
+msgstr ""
+
+#: tfreefilepreviewdialog.speedbuttonviewdetails.hint
+msgid "Details"
+msgstr ""
+
+#: tfreefilepreviewdialog.speedbuttonviewlistcompact.hint
+msgid "Icons"
+msgstr ""
+
+#: tfreefilepreviewdialog.speedbuttonviewlisthidden.hint
+msgid "View Hidden"
+msgstr ""
+
+#: tfreefilepreviewdialog.speedbuttonviewlistlarge.hint
+msgid "Large Icons"
+msgstr ""
+
+#: tfreefilepreviewdialog.speedbuttonviewlistsimple.hint
+msgid "List"
+msgstr ""
+
+#: tfreefilepreviewdialog.tabsheetplaces.caption
+msgctxt "tfreefilepreviewdialog.tabsheetplaces.caption"
+msgid "Places"
+msgstr ""
+
+#: tfreefilepreviewdialog.tabsheetplaces.hint
+msgctxt "tfreefilepreviewdialog.tabsheetplaces.hint"
+msgid "Places"
+msgstr ""
+
+#: tfreefilepreviewdialog.tabsheettree.caption
+msgctxt "tfreefilepreviewdialog.tabsheettree.caption"
+msgid "Tree"
+msgstr ""
+
+#: tfreefilepreviewdialog.tabsheettree.hint
+msgctxt "tfreefilepreviewdialog.tabsheettree.hint"
+msgid "Tree"
+msgstr ""
+
+#: tfreehullwindow.backgroundblending.caption
+msgid "Blending"
+msgstr ""
+
+#: tfreehullwindow.backgroundclear.caption
+msgctxt "tfreehullwindow.backgroundclear.caption"
+msgid "Clear"
+msgstr ""
+
+#: tfreehullwindow.backgroundexport.caption
+msgctxt "tfreehullwindow.backgroundexport.caption"
+msgid "Save"
+msgstr ""
+
+#: tfreehullwindow.backgroundimage2.caption
+msgid "Background image"
+msgstr ""
+
+#: tfreehullwindow.backgroundorigin.caption
+msgid "Origin"
+msgstr ""
+
+#: tfreehullwindow.backgroundscale.caption
+msgid "Set scale"
+msgstr ""
+
+#: tfreehullwindow.backgroundtolerance.caption
+msgid "Tolerance"
+msgstr ""
+
+#: tfreehullwindow.backgroundtransparentcolor.caption
+msgid "Transparent color"
+msgstr ""
+
+#: tfreehullwindow.backgroundvisible.caption
+msgid "Visible"
+msgstr ""
+
+#: tfreehullwindow.camera1.caption
+msgid "Camera"
+msgstr ""
+
+#: tfreehullwindow.caption
+msgid "FreeHullWindow"
+msgstr ""
+
+#: tfreehullwindow.deselectall.caption
+msgid "Deselect all     Esc"
+msgstr ""
+
+#: tfreehullwindow.importbackground.caption
+msgid "Load"
+msgstr ""
+
+#: tfreehullwindow.longtelelens.caption
+msgid "Long telelens 200 mm."
+msgstr ""
+
+#: tfreehullwindow.mediumtelelens.caption
+msgid "Medium telelens 130 mm."
+msgstr ""
+
+#: tfreehullwindow.mode1.caption
+msgid "Mode"
+msgstr ""
+
+#: tfreehullwindow.print.caption
+msgctxt "tfreehullwindow.print.caption"
+msgid "Print"
+msgstr ""
+
+#: tfreehullwindow.saveasbitmap.caption
+msgid "Save image"
+msgstr ""
+
+#: tfreehullwindow.shadezebra.caption
+msgid "Zebra shading"
+msgstr ""
+
+#: tfreehullwindow.shorttelelens.caption
+msgid "Short telelens 90 mm."
+msgstr ""
+
+#: tfreehullwindow.showdevelopablity.caption
+msgid "Developablity check"
+msgstr ""
+
+#: tfreehullwindow.showflatshade.caption
+msgctxt "tfreehullwindow.showflatshade.caption"
+msgid "Shade"
+msgstr ""
+
+#: tfreehullwindow.showgausscurvature.caption
+msgid "Gaussian curvature"
+msgstr ""
+
+#: tfreehullwindow.showwireframe.caption
+msgctxt "tfreehullwindow.showwireframe.caption"
+msgid "Wireframe"
+msgstr ""
+
+#: tfreehullwindow.standardlens.caption
+msgid "Standard lens 50mm."
+msgstr ""
+
+#: tfreehullwindow.view1.caption
+msgid "View"
+msgstr ""
+
+#: tfreehullwindow.viewbodyplan.caption
+msgid "Bodyplan"
+msgstr ""
+
+#: tfreehullwindow.viewperspective.caption
+msgid "Perspective"
+msgstr ""
+
+#: tfreehullwindow.viewplan.caption
+msgctxt "tfreehullwindow.viewplan.caption"
+msgid "Plan view"
+msgstr ""
+
+#: tfreehullwindow.viewprofile.caption
+msgid "Profile"
+msgstr ""
+
+#: tfreehullwindow.widelens.caption
+msgid "Wide lens 28 mm."
+msgstr ""
+
+#: tfreehullwindow.zoom1.caption
+msgid "Zoom"
+msgstr ""
+
+#: tfreehullwindow.zoomextents.caption
+msgctxt "tfreehullwindow.zoomextents.caption"
+msgid "All"
+msgstr ""
+
+#: tfreehullwindow.zoomin.caption
+msgctxt "tfreehullwindow.zoomin.caption"
+msgid "Zoom in"
+msgstr ""
+
+#: tfreehullwindow.zoomout.caption
+msgctxt "tfreehullwindow.zoomout.caption"
+msgid "Zoom out"
+msgstr ""
+
+#: tfreeintersectiondialog.addone.caption
+msgid "Add..."
+msgstr ""
+
+#: tfreeintersectiondialog.addone.hint
+msgid "Add one station."
+msgstr ""
+
+#: tfreeintersectiondialog.addrange.caption
+msgid "Range"
+msgstr ""
+
+#: tfreeintersectiondialog.addrange.hint
+msgid "Add a whole range of intersection curves."
+msgstr ""
+
+#: tfreeintersectiondialog.caption
+msgid "Intersections"
+msgstr ""
+
+#: tfreeintersectiondialog.closedialog.caption
+msgid "CloseDialog"
+msgstr ""
+
+#: tfreeintersectiondialog.closedialog.hint
+msgid "Close this dialog."
+msgstr ""
+
+#: tfreeintersectiondialog.deleteall.caption
+msgid "Delete all"
+msgstr ""
+
+#: tfreeintersectiondialog.deleteall.hint
+msgid "Delete all stations."
+msgstr ""
+
+#: tfreeintersectiondialog.deleteselected.caption
+msgid "DeleteSelected"
+msgstr ""
+
+#: tfreeintersectiondialog.deleteselected.hint
+msgid "Delete selected"
+msgstr ""
+
+#: tfreeintersectiondialog.sgbuttocks.columns[0].title.caption
+msgctxt "tfreeintersectiondialog.sgbuttocks.columns[0].title.caption"
+msgid "No"
+msgstr ""
+
+#: tfreeintersectiondialog.sgbuttocks.columns[1].title.caption
+msgctxt "tfreeintersectiondialog.sgbuttocks.columns[1].title.caption"
+msgid "Distance"
+msgstr ""
+
+#: tfreeintersectiondialog.sgbuttocks.columns[2].title.caption
+msgctxt "tfreeintersectiondialog.sgbuttocks.columns[2].title.caption"
+msgid "Curvature"
+msgstr ""
+
+#: tfreeintersectiondialog.sgdiagonals.columns[0].title.caption
+msgctxt "tfreeintersectiondialog.sgdiagonals.columns[0].title.caption"
+msgid "No"
+msgstr ""
+
+#: tfreeintersectiondialog.sgdiagonals.columns[1].title.caption
+msgctxt "tfreeintersectiondialog.sgdiagonals.columns[1].title.caption"
+msgid "Distance"
+msgstr ""
+
+#: tfreeintersectiondialog.sgdiagonals.columns[2].title.caption
+msgctxt "tfreeintersectiondialog.sgdiagonals.columns[2].title.caption"
+msgid "Curvature"
+msgstr ""
+
+#: tfreeintersectiondialog.sgstations.columns[0].title.caption
+msgctxt "tfreeintersectiondialog.sgstations.columns[0].title.caption"
+msgid "No"
+msgstr ""
+
+#: tfreeintersectiondialog.sgstations.columns[1].title.caption
+msgctxt "tfreeintersectiondialog.sgstations.columns[1].title.caption"
+msgid "Distance"
+msgstr ""
+
+#: tfreeintersectiondialog.sgstations.columns[2].title.caption
+msgctxt "tfreeintersectiondialog.sgstations.columns[2].title.caption"
+msgid "Curvature"
+msgstr ""
+
+#: tfreeintersectiondialog.sgwaterlines.columns[0].title.caption
+msgctxt "tfreeintersectiondialog.sgwaterlines.columns[0].title.caption"
+msgid "No"
+msgstr ""
+
+#: tfreeintersectiondialog.sgwaterlines.columns[1].title.caption
+msgctxt "tfreeintersectiondialog.sgwaterlines.columns[1].title.caption"
+msgid "Distance"
+msgstr ""
+
+#: tfreeintersectiondialog.sgwaterlines.columns[2].title.caption
+msgctxt "tfreeintersectiondialog.sgwaterlines.columns[2].title.caption"
+msgid "Curvature"
+msgstr ""
+
+#: tfreeintersectiondialog.showbuttocks.caption
+msgctxt "tfreeintersectiondialog.showbuttocks.caption"
+msgid "Buttocks"
+msgstr "Linhas do alto"
+
+#: tfreeintersectiondialog.showbuttocks.hint
+msgid "Switch to view or add buttocks."
+msgstr ""
+
+#: tfreeintersectiondialog.showdiagonals.caption
+msgctxt "tfreeintersectiondialog.showdiagonals.caption"
+msgid "Diagonals"
+msgstr ""
+
+#: tfreeintersectiondialog.showdiagonals.hint
+msgid "Switch to view or add diagonals."
+msgstr ""
+
+#: tfreeintersectiondialog.showstations.caption
+msgctxt "tfreeintersectiondialog.showstations.caption"
+msgid "Stations"
+msgstr "Balizas"
+
+#: tfreeintersectiondialog.showstations.hint
+msgid "Switch to view or add stations."
+msgstr ""
+
+#: tfreeintersectiondialog.showwaterlines.caption
+msgctxt "tfreeintersectiondialog.showwaterlines.caption"
+msgid "Waterlines"
+msgstr ""
+
+#: tfreeintersectiondialog.showwaterlines.hint
+msgid "Switch to view or add waterlines."
+msgstr ""
+
+#: tfreeintersectiondialog.toolbar1.caption
+msgctxt "tfreeintersectiondialog.toolbar1.caption"
+msgid "ToolBar1"
+msgstr ""
+
+#: tfreeintersectiondialog.toolbutton14.caption
+msgctxt "tfreeintersectiondialog.toolbutton14.caption"
+msgid "ToolButton14"
+msgstr ""
+
+#: tfreeintersectiondialog.toolbutton8.caption
+msgid "ToolButton8"
+msgstr ""
+
+#: tfreeintersectiondialog.tsbuttocks.hint
+msgctxt "tfreeintersectiondialog.tsbuttocks.hint"
+msgid "Buttocks"
+msgstr "Linhas do alto"
+
+#: tfreeintersectiondialog.tsdiagonals.hint
+msgctxt "tfreeintersectiondialog.tsdiagonals.hint"
+msgid "Diagonals"
+msgstr ""
+
+#: tfreeintersectiondialog.tsstations.hint
+msgctxt "tfreeintersectiondialog.tsstations.hint"
+msgid "Stations"
+msgstr "Balizas"
+
+#: tfreeintersectiondialog.tswaterlines.hint
+msgctxt "tfreeintersectiondialog.tswaterlines.hint"
+msgid "Waterlines"
+msgstr ""
+
+#: tfreekeelwizarddialog.actionmodeshade.caption
+msgctxt "tfreekeelwizarddialog.actionmodeshade.caption"
+msgid "Shade"
+msgstr ""
+
+#: tfreekeelwizarddialog.actionmodewireframe.caption
+msgctxt "tfreekeelwizarddialog.actionmodewireframe.caption"
+msgid "Wireframe"
+msgstr ""
+
+#: tfreekeelwizarddialog.actionsetlayercolor.caption
+msgctxt "tfreekeelwizarddialog.actionsetlayercolor.caption"
+msgid "Set Layer Color"
+msgstr ""
+
+#: tfreekeelwizarddialog.actionsetlayercolor.hint
+msgctxt "tfreekeelwizarddialog.actionsetlayercolor.hint"
+msgid "Set Layer Color"
+msgstr ""
+
+#: tfreekeelwizarddialog.actionshowbothsides.caption
+msgctxt "tfreekeelwizarddialog.actionshowbothsides.caption"
+msgid "Show Both Sides"
+msgstr ""
+
+#: tfreekeelwizarddialog.actionshowcontrolnet.caption
+msgctxt "tfreekeelwizarddialog.actionshowcontrolnet.caption"
+msgid "Show Control Net"
+msgstr ""
+
+#: tfreekeelwizarddialog.actionshowinterioredges.caption
+msgctxt "tfreekeelwizarddialog.actionshowinterioredges.caption"
+msgid "Show Interior Edges"
+msgstr ""
+
+#: tfreekeelwizarddialog.bitbtn1.caption
+msgctxt "tfreekeelwizarddialog.bitbtn1.caption"
+msgid "OK"
+msgstr ""
+
+#: tfreekeelwizarddialog.bitbtn2.caption
+msgctxt "tfreekeelwizarddialog.bitbtn2.caption"
+msgid "Cancel"
+msgstr ""
+
+#: tfreekeelwizarddialog.button1.caption
+msgctxt "tfreekeelwizarddialog.button1.caption"
+msgid "Calc"
+msgstr ""
+
+#: tfreekeelwizarddialog.button2.caption
+msgctxt "tfreekeelwizarddialog.button2.caption"
+msgid "Calc"
+msgstr ""
+
+#: tfreekeelwizarddialog.caption
+msgctxt "tfreekeelwizarddialog.caption"
+msgid "Keel and rudder wizard"
+msgstr ""
+
+#: tfreekeelwizarddialog.combobox.text
+msgctxt "tfreekeelwizarddialog.combobox.text"
+msgid "Keel"
+msgstr "Quilha"
+
+#: tfreekeelwizarddialog.comboboxplanformshape.text
+msgid "Trapezoidal"
+msgstr ""
+
+#: tfreekeelwizarddialog.comboboxsubdivisionlevel.hint
+msgid "Desired Subdivision Level"
+msgstr ""
+
+#: tfreekeelwizarddialog.comboboxsubdivisionlevel.text
+msgctxt "tfreekeelwizarddialog.comboboxsubdivisionlevel.text"
+msgid "Medium"
+msgstr ""
+
+#: tfreekeelwizarddialog.groupbox1.caption
+msgctxt "tfreekeelwizarddialog.groupbox1.caption"
+msgid "Properties"
+msgstr ""
+
+#: tfreekeelwizarddialog.inputbulbshape.text
+msgid "No bullb"
+msgstr ""
+
+#: tfreekeelwizarddialog.inputbulbwing.text
+msgid "NACA0020"
+msgstr ""
+
+#: tfreekeelwizarddialog.inputmaterial.text
+msgid "Plumbum"
+msgstr ""
+
+#: tfreekeelwizarddialog.label1.caption
+msgid "Type of appendage"
+msgstr ""
+
+#: tfreekeelwizarddialog.label10.caption
+msgid "Wing width"
+msgstr ""
+
+#: tfreekeelwizarddialog.label11.caption
+msgid "Mean chord length"
+msgstr ""
+
+#: tfreekeelwizarddialog.label12.caption
+msgctxt "tfreekeelwizarddialog.label12.caption"
+msgid "Wing section"
+msgstr ""
+
+#: tfreekeelwizarddialog.label13.caption
+msgid "Geometric aspect ratio"
+msgstr ""
+
+#: tfreekeelwizarddialog.label14.caption
+msgctxt "tfreekeelwizarddialog.label14.caption"
+msgid "Length"
+msgstr "Comprimento"
+
+#: tfreekeelwizarddialog.label15.caption
+msgid "Effective aspect ratio"
+msgstr ""
+
+#: tfreekeelwizarddialog.label16.caption
+msgctxt "tfreekeelwizarddialog.label16.caption"
+msgid "No horizontal points"
+msgstr ""
+
+#: tfreekeelwizarddialog.label17.caption
+msgctxt "tfreekeelwizarddialog.label17.caption"
+msgid "Wing section"
+msgstr ""
+
+#: tfreekeelwizarddialog.label18.caption
+msgctxt "tfreekeelwizarddialog.label18.caption"
+msgid "Volume"
+msgstr ""
+
+#: tfreekeelwizarddialog.label19.caption
+msgid "Bulb's material"
+msgstr ""
+
+#: tfreekeelwizarddialog.label2.caption
+msgctxt "tfreekeelwizarddialog.label2.caption"
+msgid "Planform shape"
+msgstr ""
+
+#: tfreekeelwizarddialog.label20.caption
+msgid "Volume COG"
+msgstr ""
+
+#: tfreekeelwizarddialog.label21.caption
+msgctxt "tfreekeelwizarddialog.label21.caption"
+msgid "Specific weight"
+msgstr ""
+
+#: tfreekeelwizarddialog.label22.caption
+msgctxt "tfreekeelwizarddialog.label22.caption"
+msgid "Wetted area"
+msgstr "Área molhada"
+
+#: tfreekeelwizarddialog.label23.caption
+msgctxt "tfreekeelwizarddialog.label23.caption"
+msgid "Vertical compression"
+msgstr ""
+
+#: tfreekeelwizarddialog.label24.caption
+msgctxt "tfreekeelwizarddialog.label24.caption"
+msgid "Thickness"
+msgstr ""
+
+#: tfreekeelwizarddialog.label25.caption
+msgctxt "tfreekeelwizarddialog.label25.caption"
+msgid "Delta tip"
+msgstr ""
+
+#: tfreekeelwizarddialog.label26.caption
+msgid "No. vertical points"
+msgstr ""
+
+#: tfreekeelwizarddialog.label27.caption
+msgctxt "tfreekeelwizarddialog.label27.caption"
+msgid "No horizontal points"
+msgstr ""
+
+#: tfreekeelwizarddialog.label28.caption
+msgctxt "tfreekeelwizarddialog.label28.caption"
+msgid "Vertical compression"
+msgstr ""
+
+#: tfreekeelwizarddialog.label29.caption
+msgid "Bulb weight"
+msgstr ""
+
+#: tfreekeelwizarddialog.label3.caption
+msgid "Root chord length"
+msgstr ""
+
+#: tfreekeelwizarddialog.label30.caption
+msgid "Horizontal compression"
+msgstr ""
+
+#: tfreekeelwizarddialog.label4.caption
+msgid "Tip chord length"
+msgstr ""
+
+#: tfreekeelwizarddialog.label5.caption
+msgid "Span"
+msgstr ""
+
+#: tfreekeelwizarddialog.label6.caption
+msgctxt "tfreekeelwizarddialog.label6.caption"
+msgid "Delta tip"
+msgstr ""
+
+#: tfreekeelwizarddialog.label7.caption
+msgid "Planform area"
+msgstr ""
+
+#: tfreekeelwizarddialog.label8.caption
+msgctxt "tfreekeelwizarddialog.label8.caption"
+msgid "Planform shape"
+msgstr ""
+
+#: tfreekeelwizarddialog.label9.caption
+msgid "Planform COG"
+msgstr ""
+
+#: tfreekeelwizarddialog.layercolorbutton.hint
+msgctxt "tfreekeelwizarddialog.layercolorbutton.hint"
+msgid "Set Layer Color"
+msgstr ""
+
+#: tfreekeelwizarddialog.panel7.caption
+msgid "Panel7"
+msgstr ""
+
+#: tfreekeelwizarddialog.sbshowbothsides.hint
+msgctxt "tfreekeelwizarddialog.sbshowbothsides.hint"
+msgid "Show Both Sides"
+msgstr ""
+
+#: tfreekeelwizarddialog.sbshowcontrolnet.hint
+msgctxt "tfreekeelwizarddialog.sbshowcontrolnet.hint"
+msgid "Show Control Net"
+msgstr ""
+
+#: tfreekeelwizarddialog.sbshowinterioredges.hint
+msgctxt "tfreekeelwizarddialog.sbshowinterioredges.hint"
+msgid "Show Interior Edges"
+msgstr ""
+
+#: tfreekeelwizarddialog.speedbutton1.caption
+msgid "Send"
+msgstr ""
+
+#: tfreekeelwizarddialog.speedbutton2.caption
+msgid "Save as part"
+msgstr ""
+
+#: tfreekeelwizarddialog.tabsheet1.caption
+msgid "3D view"
+msgstr ""
+
+#: tfreekeelwizarddialog.tabsheet2.caption
+msgid "Lift and drag"
+msgstr ""
+
+#: tfreekeelwizarddialog.tabsheet3.caption
+msgctxt "tfreekeelwizarddialog.tabsheet3.caption"
+msgid "Keel"
+msgstr "Quilha"
+
+#: tfreekeelwizarddialog.tabsheet4.caption
+msgid "Bulb"
+msgstr ""
+
+#: tfreekeelwizarddialog._combobox2.text
+msgid "NACA63-006"
+msgstr ""
+
+#: tfreekeelwizarddialog._label10.caption
+msgid "_Label10"
+msgstr ""
+
+#: tfreekeelwizarddialog._label12.caption
+msgctxt "tfreekeelwizarddialog._label12.caption"
+msgid "Label10"
+msgstr ""
+
+#: tfreekeelwizarddialog._label14.caption
+msgctxt "tfreekeelwizarddialog._label14.caption"
+msgid "Label10"
+msgstr ""
+
+#: tfreekeelwizarddialog._label16.caption
+msgctxt "tfreekeelwizarddialog._label16.caption"
+msgid "Label10"
+msgstr ""
+
+#: tfreekeelwizarddialog._label19.caption
+msgctxt "tfreekeelwizarddialog._label19.caption"
+msgid "Label8"
+msgstr ""
+
+#: tfreekeelwizarddialog._label21.caption
+msgctxt "tfreekeelwizarddialog._label21.caption"
+msgid "Label8"
+msgstr ""
+
+#: tfreekeelwizarddialog._label23.caption
+msgctxt "tfreekeelwizarddialog._label23.caption"
+msgid "Label8"
+msgstr ""
+
+#: tfreekeelwizarddialog._label25.caption
+msgctxt "tfreekeelwizarddialog._label25.caption"
+msgid "Label10"
+msgstr ""
+
+#: tfreekeelwizarddialog._label8.caption
+msgid "_Label8"
+msgstr ""
+
+#: tfreepreferencesdialog.bitbtn1.caption
+msgctxt "tfreepreferencesdialog.bitbtn1.caption"
+msgid "OK"
+msgstr ""
+
+#: tfreepreferencesdialog.bitbtn2.caption
+msgctxt "tfreepreferencesdialog.bitbtn2.caption"
+msgid "Cancel"
+msgstr ""
+
+#: tfreepreferencesdialog.bitbtnresetcolors.caption
+msgctxt "tfreepreferencesdialog.bitbtnresetcolors.caption"
+msgid "Reset"
+msgstr ""
+
+#: tfreepreferencesdialog.bitbtnresetdirs.caption
+msgctxt "tfreepreferencesdialog.bitbtnresetdirs.caption"
+msgid "Reset"
+msgstr ""
+
+#: tfreepreferencesdialog.caption
+msgid "|Preferences.|"
+msgstr ""
+
+#: tfreepreferencesdialog.combobox1.text
+msgctxt "tfreepreferencesdialog.combobox1.text"
+msgid "ComboBox1"
+msgstr ""
+
+#: tfreepreferencesdialog.comboboxencoding.hint
+msgid ""
+"Encoding for FBM files\n"
+"Used to convert Windows encoded strings to UTF8"
+msgstr ""
+
+#: tfreepreferencesdialog.comboboxthemes.text
+msgid "ComboBoxThemes"
+msgstr ""
+
+#: tfreepreferencesdialog.editexecdir.text
+msgid "EditExecDir"
+msgstr ""
+
+#: tfreepreferencesdialog.editexportdir.text
+msgid "EditExportDir"
+msgstr ""
+
+#: tfreepreferencesdialog.editglobalimportdir.text
+msgid "EditGlobalImportDir"
+msgstr ""
+
+#: tfreepreferencesdialog.editglobalopendir.text
+msgid "EditGlobalOpenDir"
+msgstr ""
+
+#: tfreepreferencesdialog.editimportdir.text
+msgid "EditImportDir"
+msgstr ""
+
+#: tfreepreferencesdialog.editlanguagesdir.text
+msgid "EditLanguagesDir"
+msgstr ""
+
+#: tfreepreferencesdialog.editmanualsdir.text
+msgid "EditManualsDir"
+msgstr ""
+
+#: tfreepreferencesdialog.editopendir.text
+msgid "EditOpenDir"
+msgstr ""
+
+#: tfreepreferencesdialog.editsavedir.text
+msgid "EditSaveDir"
+msgstr ""
+
+#: tfreepreferencesdialog.edittempdir.text
+msgid "EditTempDir"
+msgstr ""
+
+#: tfreepreferencesdialog.label1.caption
+msgid "Viewport background"
+msgstr ""
+
+#: tfreepreferencesdialog.label10.caption
+msgid "Dart points"
+msgstr ""
+
+#: tfreepreferencesdialog.label11.caption
+msgid "Selected items"
+msgstr ""
+
+#: tfreepreferencesdialog.label12.caption
+msgid "Viewport grid"
+msgstr ""
+
+#: tfreepreferencesdialog.label13.caption
+msgid "Grid font"
+msgstr ""
+
+#: tfreepreferencesdialog.label14.caption
+msgctxt "tfreepreferencesdialog.label14.caption"
+msgid "Stations"
+msgstr "Balizas"
+
+#: tfreepreferencesdialog.label15.caption
+msgctxt "tfreepreferencesdialog.label15.caption"
+msgid "Buttocks"
+msgstr "Linhas do alto"
+
+#: tfreepreferencesdialog.label16.caption
+msgctxt "tfreepreferencesdialog.label16.caption"
+msgid "Waterlines"
+msgstr ""
+
+#: tfreepreferencesdialog.label17.caption
+msgid "Controlpoint size"
+msgstr ""
+
+#: tfreepreferencesdialog.label18.caption
+msgid "Surface normals"
+msgstr ""
+
+#: tfreepreferencesdialog.label19.caption
+msgctxt "tfreepreferencesdialog.label19.caption"
+msgid "Diagonals"
+msgstr ""
+
+#: tfreepreferencesdialog.label2.caption
+msgid "New surfaces"
+msgstr ""
+
+#: tfreepreferencesdialog.label20.caption
+msgid "Leak points"
+msgstr ""
+
+#: tfreepreferencesdialog.label21.caption
+msgctxt "tfreepreferencesdialog.label21.caption"
+msgid "Markers"
+msgstr ""
+
+#: tfreepreferencesdialog.label22.caption
+msgid "Curvature plots"
+msgstr ""
+
+#: tfreepreferencesdialog.label23.caption
+msgctxt "tfreepreferencesdialog.label23.caption"
+msgid "Control curves"
+msgstr ""
+
+#: tfreepreferencesdialog.label24.caption
+msgid "Hydrostatics font color"
+msgstr ""
+
+#: tfreepreferencesdialog.label25.caption
+msgid "Zebra stripes color"
+msgstr ""
+
+#: tfreepreferencesdialog.label26.caption
+msgid "Language"
+msgstr ""
+
+#: tfreepreferencesdialog.label27.caption
+msgid "Max. undo memory (Mb)"
+msgstr ""
+
+#: tfreepreferencesdialog.label29.caption
+msgid "Manuals"
+msgstr ""
+
+#: tfreepreferencesdialog.label3.caption
+msgid "Submerged surfaces"
+msgstr ""
+
+#: tfreepreferencesdialog.label30.caption
+msgid "Executables"
+msgstr ""
+
+#: tfreepreferencesdialog.label31.caption
+msgid "Temporary"
+msgstr ""
+
+#: tfreepreferencesdialog.label32.caption
+msgctxt "tfreepreferencesdialog.label32.caption"
+msgid "Open"
+msgstr ""
+
+#: tfreepreferencesdialog.label33.caption
+msgctxt "tfreepreferencesdialog.label33.caption"
+msgid "Save"
+msgstr ""
+
+#: tfreepreferencesdialog.label34.caption
+msgctxt "tfreepreferencesdialog.label34.caption"
+msgid "Import"
+msgstr ""
+
+#: tfreepreferencesdialog.label35.caption
+msgctxt "tfreepreferencesdialog.label35.caption"
+msgid "Export"
+msgstr ""
+
+#: tfreepreferencesdialog.label36.caption
+msgid "Global Open"
+msgstr ""
+
+#: tfreepreferencesdialog.label37.caption
+msgid "Tool icon size"
+msgstr ""
+
+#: tfreepreferencesdialog.label38.caption
+msgid "Theme"
+msgstr ""
+
+#: tfreepreferencesdialog.label39.caption
+msgctxt "tfreepreferencesdialog.label39.caption"
+msgid "Global Import"
+msgstr ""
+
+#: tfreepreferencesdialog.label4.caption
+msgid "Regular control edges"
+msgstr ""
+
+#: tfreepreferencesdialog.label5.caption
+msgid "Crease edges (control)"
+msgstr ""
+
+#: tfreepreferencesdialog.label6.caption
+msgid "Crease edges (interior)"
+msgstr ""
+
+#: tfreepreferencesdialog.label7.caption
+msgid "Regular control points"
+msgstr ""
+
+#: tfreepreferencesdialog.label8.caption
+msgid "Crease points"
+msgstr ""
+
+#: tfreepreferencesdialog.label9.caption
+msgid "Corner points"
+msgstr ""
+
+#: tfreepreferencesdialog.labelencoding.caption
+msgid "Encoding for FBM"
+msgstr ""
+
+#: tfreepreferencesdialog.labellanguagesdir.caption
+msgid "Languages"
+msgstr ""
+
+#: tfreepreferencesdialog.panel29.caption
+msgctxt "tfreepreferencesdialog.panel29.caption"
+msgid "Panel29"
+msgstr ""
+
+#: tfreepreferencesdialog.panel33.caption
+msgctxt "tfreepreferencesdialog.panel33.caption"
+msgid "Panel29"
+msgstr ""
+
+#: tfreepreferencesdialog.panel35.caption
+msgctxt "tfreepreferencesdialog.panel35.caption"
+msgid "Panel29"
+msgstr ""
+
+#: tfreepreferencesdialog.panel39.caption
+msgctxt "tfreepreferencesdialog.panel39.caption"
+msgid "Panel29"
+msgstr ""
+
+#: tfreepreferencesdialog.panel45.caption
+msgctxt "tfreepreferencesdialog.panel45.caption"
+msgid "Panel29"
+msgstr ""
+
+#: tfreepreferencesdialog.panel51.caption
+msgid "Panel51"
+msgstr ""
+
+#: tfreepreferencesdialog.selecttooliconsize.text
+msgid "24"
+msgstr ""
+
+#: tfreepreferencesdialog.tabsheet1.caption
+msgctxt "tfreepreferencesdialog.tabsheet1.caption"
+msgid "General"
+msgstr ""
+
+#: tfreepreferencesdialog.tabsheet2.caption
+msgid "Directories"
+msgstr ""
+
+#: tfreepreferencesdialog.tabsheet3.caption
+msgid "Graphics"
+msgstr ""
+
+#: tfreepropeller_task5.caption
+msgid "Calculation of Open Water Characteristics of Screw Propeller."
+msgstr ""
+
+#: tfreepropeller_task5.checkbox2.caption
+msgctxt "tfreepropeller_task5.checkbox2.caption"
+msgid "Extract data from current hull"
+msgstr ""
+
+#: tfreepropeller_task5.combobox.text
+msgid "B series Troost"
+msgstr ""
+
+#: tfreepropeller_task5.combobox1.text
+msgid "Reserved"
+msgstr ""
+
+#: tfreepropeller_task5.label2.caption
+msgid "Frequancy of rotation, 1/min"
+msgstr ""
+
+#: tfreepropeller_task5.label3.caption
+msgctxt "tfreepropeller_task5.label3.caption"
+msgid "Disk ratio"
+msgstr ""
+
+#: tfreepropeller_task5.label4.caption
+msgctxt "tfreepropeller_task5.label4.caption"
+msgid "Pitch fraction"
+msgstr ""
+
+#: tfreepropeller_task5.label5.caption
+msgctxt "tfreepropeller_task5.label5.caption"
+msgid "Number of blade"
+msgstr ""
+
+#: tfreepropeller_task5.label6.caption
+msgid "Diameter of propeller, m"
+msgstr ""
+
+#: tfreepropeller_task5.label7.caption
+msgid "Velocity in propeller disk, m/s"
+msgstr ""
+
+#: tfreepropeller_task5.label8.caption
+msgid "Type of propeller:"
+msgstr ""
+
+#: tfreepropeller_task5.label9.caption
+msgid "Series of propeller:"
+msgstr ""
+
+#: tfreepropeller_task5.printbutton.caption
+msgctxt "tfreepropeller_task5.printbutton.caption"
+msgid "PrintButton"
+msgstr ""
+
+#: tfreepropeller_task5.printbutton.hint
+msgctxt "tfreepropeller_task5.printbutton.hint"
+msgid "Print the results of the calculation."
+msgstr ""
+
+#: tfreepropeller_task5.tabsheet1.caption
+msgctxt "tfreepropeller_task5.tabsheet1.caption"
+msgid "General"
+msgstr ""
+
+#: tfreepropeller_task5.tabsheet2.caption
+msgctxt "tfreepropeller_task5.tabsheet2.caption"
+msgid "Results"
+msgstr ""
+
+#: tfreepropeller_task5.toolbar1.caption
+msgctxt "tfreepropeller_task5.toolbar1.caption"
+msgid "ToolBar1"
+msgstr ""
+
+#: tfreepropeller_task5.toolbutton17.hint
+msgctxt "tfreepropeller_task5.toolbutton17.hint"
+msgid "Start engine selection"
+msgstr ""
+
+#: tfreepropeller_task5.toolbutton25.hint
+msgctxt "tfreepropeller_task5.toolbutton25.hint"
+msgid "Close the window and save changes."
+msgstr ""
+
+#: tfreepropeller_task5.toolbutton7.hint
+msgctxt "tfreepropeller_task5.toolbutton7.hint"
+msgid "Close window without saving changes."
+msgstr ""
+
+#: tfreepropeller_task5._toolbutton10.caption
+msgctxt "tfreepropeller_task5._toolbutton10.caption"
+msgid "_ToolButton10"
+msgstr ""
+
+#: tfreepropeller_task5._toolbutton14.caption
+msgctxt "tfreepropeller_task5._toolbutton14.caption"
+msgid "_ToolButton14"
+msgstr ""
+
+#: tfreeresistance_delft.caption
+msgid "Resistance for Sailing Yachts or a Sea Ships"
+msgstr ""
+
+#: tfreeresistance_delft.checkbox2.caption
+msgctxt "tfreeresistance_delft.checkbox2.caption"
+msgid "Extract data from current hull"
+msgstr ""
+
+#: tfreeresistance_delft.estimatebox.caption
+msgctxt "tfreeresistance_delft.estimatebox.caption"
+msgid "Use estimate"
+msgstr ""
+
+#: tfreeresistance_delft.general.caption
+msgctxt "tfreeresistance_delft.general.caption"
+msgid "General"
+msgstr ""
+
+#: tfreeresistance_delft.groupbox1.caption
+msgctxt "tfreeresistance_delft.groupbox1.caption"
+msgid "General"
+msgstr ""
+
+#: tfreeresistance_delft.groupbox2.caption
+msgctxt "tfreeresistance_delft.groupbox2.caption"
+msgid "Hull"
+msgstr "Casco"
+
+#: tfreeresistance_delft.groupbox3.caption
+msgctxt "tfreeresistance_delft.groupbox3.caption"
+msgid "Keel"
+msgstr "Quilha"
+
+#: tfreeresistance_delft.groupbox4.caption
+msgctxt "tfreeresistance_delft.groupbox4.caption"
+msgid "Rudder"
+msgstr "Leme"
+
+#: tfreeresistance_delft.label1.caption
+msgctxt "tfreeresistance_delft.label1.caption"
+msgid "Start speed"
+msgstr ""
+
+#: tfreeresistance_delft.label13.caption
+msgctxt "tfreeresistance_delft.label13.caption"
+msgid "Wetted surface"
+msgstr "Superfície molhada"
+
+#: tfreeresistance_delft.label2.caption
+msgctxt "tfreeresistance_delft.label2.caption"
+msgid "End speed "
+msgstr ""
+
+#: tfreeresistance_delft.label20.caption
+msgctxt "tfreeresistance_delft.label20.caption"
+msgid "Total draft"
+msgstr ""
+
+#: tfreeresistance_delft.label21.caption
+msgctxt "tfreeresistance_delft.label21.caption"
+msgid "Draft hull"
+msgstr "Calado do casco"
+
+#: tfreeresistance_delft.label22.caption
+msgctxt "tfreeresistance_delft.label22.caption"
+msgid "Beam waterline "
+msgstr ""
+
+#: tfreeresistance_delft.label23.caption
+msgctxt "tfreeresistance_delft.label23.caption"
+msgid "Length waterline"
+msgstr ""
+
+#: tfreeresistance_delft.label24.caption
+msgctxt "tfreeresistance_delft.label24.caption"
+msgid "Prismatic coefficient "
+msgstr ""
+
+#: tfreeresistance_delft.label25.caption
+msgctxt "tfreeresistance_delft.label25.caption"
+msgid "LCB"
+msgstr ""
+
+#: tfreeresistance_delft.label26.caption
+msgctxt "tfreeresistance_delft.label26.caption"
+msgid "Displacement"
+msgstr "Deslocamento"
+
+#: tfreeresistance_delft.label27.caption
+msgctxt "tfreeresistance_delft.label27.caption"
+msgid "Waterplane area"
+msgstr ""
+
+#: tfreeresistance_delft.label29.caption
+msgctxt "tfreeresistance_delft.label29.caption"
+msgid "Average chordlength"
+msgstr ""
+
+#: tfreeresistance_delft.label3.caption
+msgctxt "tfreeresistance_delft.label3.caption"
+msgid "Step"
+msgstr ""
+
+#: tfreeresistance_delft.label34.caption
+msgctxt "tfreeresistance_delft.label34.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_delft.label4.caption
+msgctxt "tfreeresistance_delft.label4.caption"
+msgid "Water density"
+msgstr ""
+
+#: tfreeresistance_delft.label5.caption
+msgctxt "tfreeresistance_delft.label5.caption"
+msgid "Viscosity"
+msgstr ""
+
+#: tfreeresistance_delft.label6.caption
+msgctxt "tfreeresistance_delft.label6.caption"
+msgid "Average chordlength"
+msgstr ""
+
+#: tfreeresistance_delft.label7.caption
+msgctxt "tfreeresistance_delft.label7.caption"
+msgid "Wetted area"
+msgstr "Área molhada"
+
+#: tfreeresistance_delft.label8.caption
+msgctxt "tfreeresistance_delft.label8.caption"
+msgid "Wetted area"
+msgstr "Área molhada"
+
+#: tfreeresistance_delft.printbutton.caption
+msgctxt "tfreeresistance_delft.printbutton.caption"
+msgid "PrintButton"
+msgstr ""
+
+#: tfreeresistance_delft.printbutton.hint
+msgctxt "tfreeresistance_delft.printbutton.hint"
+msgid "Print the results of the calculation."
+msgstr ""
+
+#: tfreeresistance_delft.results.caption
+msgctxt "tfreeresistance_delft.results.caption"
+msgid "Results"
+msgstr ""
+
+#: tfreeresistance_delft.toolbar1.caption
+msgctxt "tfreeresistance_delft.toolbar1.caption"
+msgid "ToolBar1"
+msgstr ""
+
+#: tfreeresistance_delft.toolbutton20.hint
+msgctxt "tfreeresistance_delft.toolbutton20.hint"
+msgid "Start the calculation."
+msgstr ""
+
+#: tfreeresistance_delft.toolbutton25.hint
+msgctxt "tfreeresistance_delft.toolbutton25.hint"
+msgid "Close the window and save changes."
+msgstr ""
+
+#: tfreeresistance_delft.toolbutton7.hint
+msgctxt "tfreeresistance_delft.toolbutton7.hint"
+msgid "Close window without saving changes."
+msgstr ""
+
+#: tfreeresistance_delft._label10.caption
+msgctxt "tfreeresistance_delft._label10.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_delft._label11.caption
+msgctxt "tfreeresistance_delft._label11.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_delft._label12.caption
+msgctxt "tfreeresistance_delft._label12.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_delft._label14.caption
+msgctxt "tfreeresistance_delft._label14.caption"
+msgid "[m2]"
+msgstr ""
+
+#: tfreeresistance_delft._label15.caption
+msgctxt "tfreeresistance_delft._label15.caption"
+msgid "[m2]"
+msgstr ""
+
+#: tfreeresistance_delft._label16.caption
+msgctxt "tfreeresistance_delft._label16.caption"
+msgid "[%]"
+msgstr ""
+
+#: tfreeresistance_delft._label17.caption
+msgctxt "tfreeresistance_delft._label17.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_delft._label18.caption
+msgctxt "tfreeresistance_delft._label18.caption"
+msgid "[m2]"
+msgstr ""
+
+#: tfreeresistance_delft._label19.caption
+msgctxt "tfreeresistance_delft._label19.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_delft._label20.caption
+msgctxt "tfreeresistance_delft._label20.caption"
+msgid "[%]"
+msgstr ""
+
+#: tfreeresistance_delft._label30.caption
+msgctxt "tfreeresistance_delft._label30.caption"
+msgid "[m2]"
+msgstr ""
+
+#: tfreeresistance_delft._label31.caption
+msgctxt "tfreeresistance_delft._label31.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_delft._label32.caption
+msgctxt "tfreeresistance_delft._label32.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_delft._label33.caption
+msgctxt "tfreeresistance_delft._label33.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_delft._label36.caption
+msgctxt "tfreeresistance_delft._label36.caption"
+msgid "*10-6  m2/s"
+msgstr ""
+
+#: tfreeresistance_delft._label8.caption
+msgctxt "tfreeresistance_delft._label8.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_delft._label9.caption
+msgctxt "tfreeresistance_delft._label9.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_delft._toolbutton10.caption
+msgctxt "tfreeresistance_delft._toolbutton10.caption"
+msgid "_ToolButton10"
+msgstr ""
+
+#: tfreeresistance_delft._toolbutton14.caption
+msgctxt "tfreeresistance_delft._toolbutton14.caption"
+msgid "_ToolButton14"
+msgstr ""
+
+#: tfreeresistance_fungleib.a11box.text
+msgctxt "tfreeresistance_fungleib.a11box.text"
+msgid "Passenger ship and ferry"
+msgstr ""
+
+#: tfreeresistance_fungleib.caption
+msgid "Resistance for naval ships by Fung-Leibmans method 1995"
+msgstr ""
+
+#: tfreeresistance_fungleib.chart.axislist[0].title.caption
+msgctxt "tfreeresistance_fungleib.chart.axislist[0].title.caption"
+msgid "Resistance [kN]"
+msgstr "Resistência [kN]"
+
+#: tfreeresistance_fungleib.chart.axislist[1].title.caption
+msgctxt "tfreeresistance_fungleib.chart.axislist[1].title.caption"
+msgid "Speed [knots]"
+msgstr ""
+
+#: tfreeresistance_fungleib.chart.axislist[2].title.caption
+msgctxt "tfreeresistance_fungleib.chart.axislist[2].title.caption"
+msgid "Power [kW]"
+msgstr ""
+
+#: tfreeresistance_fungleib.checkbox2.caption
+msgctxt "tfreeresistance_fungleib.checkbox2.caption"
+msgid "Extract data from current hull"
+msgstr ""
+
+#: tfreeresistance_fungleib.data2.caption
+msgctxt "tfreeresistance_fungleib.data2.caption"
+msgid "Added data"
+msgstr ""
+
+#: tfreeresistance_fungleib.estimate2box.caption
+msgctxt "tfreeresistance_fungleib.estimate2box.caption"
+msgid "Use calculated"
+msgstr ""
+
+#: tfreeresistance_fungleib.estimatebox.caption
+msgctxt "tfreeresistance_fungleib.estimatebox.caption"
+msgid "Use estimate"
+msgstr ""
+
+#: tfreeresistance_fungleib.general.caption
+msgctxt "tfreeresistance_fungleib.general.caption"
+msgid "General"
+msgstr ""
+
+#: tfreeresistance_fungleib.groupbox1.caption
+msgctxt "tfreeresistance_fungleib.groupbox1.caption"
+msgid "General"
+msgstr ""
+
+#: tfreeresistance_fungleib.groupbox2.caption
+msgctxt "tfreeresistance_fungleib.groupbox2.caption"
+msgid "Hull"
+msgstr "Casco"
+
+#: tfreeresistance_fungleib.groupbox3.caption
+msgctxt "tfreeresistance_fungleib.groupbox3.caption"
+msgid "Added data input:"
+msgstr ""
+
+#: tfreeresistance_fungleib.groupbox4.caption
+msgctxt "tfreeresistance_fungleib.groupbox4.caption"
+msgid "Number of appendages :"
+msgstr ""
+
+#: tfreeresistance_fungleib.label1.caption
+msgctxt "tfreeresistance_fungleib.label1.caption"
+msgid "Start speed"
+msgstr ""
+
+#: tfreeresistance_fungleib.label10.caption
+msgctxt "tfreeresistance_fungleib.label10.caption"
+msgid "1/2 entrance angle, degr"
+msgstr ""
+
+#: tfreeresistance_fungleib.label11.caption
+msgid "Transom beam, m"
+msgstr ""
+
+#: tfreeresistance_fungleib.label13.caption
+msgctxt "tfreeresistance_fungleib.label13.caption"
+msgid "Wetted surface"
+msgstr "Superfície molhada"
+
+#: tfreeresistance_fungleib.label14.caption
+msgid "Propeller type (1-CRPP; 2-FPP)"
+msgstr ""
+
+#: tfreeresistance_fungleib.label15.caption
+msgctxt "tfreeresistance_fungleib.label15.caption"
+msgid "Number of propellers"
+msgstr ""
+
+#: tfreeresistance_fungleib.label16.caption
+msgctxt "tfreeresistance_fungleib.label16.caption"
+msgid "Propeller diameter, m"
+msgstr ""
+
+#: tfreeresistance_fungleib.label17.caption
+msgctxt "tfreeresistance_fungleib.label17.caption"
+msgid "Absolute roughness, mkm"
+msgstr ""
+
+#: tfreeresistance_fungleib.label2.caption
+msgctxt "tfreeresistance_fungleib.label2.caption"
+msgid "End speed "
+msgstr ""
+
+#: tfreeresistance_fungleib.label20.caption
+msgctxt "tfreeresistance_fungleib.label20.caption"
+msgid "Midship draft"
+msgstr ""
+
+#: tfreeresistance_fungleib.label21.caption
+msgctxt "tfreeresistance_fungleib.label21.caption"
+msgid "Different"
+msgstr ""
+
+#: tfreeresistance_fungleib.label22.caption
+msgctxt "tfreeresistance_fungleib.label22.caption"
+msgid "Beam waterline "
+msgstr ""
+
+#: tfreeresistance_fungleib.label23.caption
+msgctxt "tfreeresistance_fungleib.label23.caption"
+msgid "Length waterline"
+msgstr ""
+
+#: tfreeresistance_fungleib.label24.caption
+msgctxt "tfreeresistance_fungleib.label24.caption"
+msgid "Prismatic coefficient "
+msgstr ""
+
+#: tfreeresistance_fungleib.label25.caption
+msgctxt "tfreeresistance_fungleib.label25.caption"
+msgid "LCB"
+msgstr ""
+
+#: tfreeresistance_fungleib.label26.caption
+msgctxt "tfreeresistance_fungleib.label26.caption"
+msgid "Displacement"
+msgstr "Deslocamento"
+
+#: tfreeresistance_fungleib.label27.caption
+msgctxt "tfreeresistance_fungleib.label27.caption"
+msgid "Length over surface"
+msgstr ""
+
+#: tfreeresistance_fungleib.label281.caption
+msgctxt "tfreeresistance_fungleib.label281.caption"
+msgid "Keel and skeg:"
+msgstr ""
+
+#: tfreeresistance_fungleib.label29.caption
+msgctxt "tfreeresistance_fungleib.label29.caption"
+msgid "Skeg"
+msgstr ""
+
+#: tfreeresistance_fungleib.label3.caption
+msgctxt "tfreeresistance_fungleib.label3.caption"
+msgid "Step"
+msgstr ""
+
+#: tfreeresistance_fungleib.label30.caption
+msgctxt "tfreeresistance_fungleib.label30.caption"
+msgid "Shaft brackets"
+msgstr ""
+
+#: tfreeresistance_fungleib.label31.caption
+msgctxt "tfreeresistance_fungleib.label31.caption"
+msgid "Strut bossing"
+msgstr ""
+
+#: tfreeresistance_fungleib.label32.caption
+msgctxt "tfreeresistance_fungleib.label32.caption"
+msgid "Hull bossing"
+msgstr ""
+
+#: tfreeresistance_fungleib.label33.caption
+msgctxt "tfreeresistance_fungleib.label33.caption"
+msgid "Exposed shafts:"
+msgstr ""
+
+#: tfreeresistance_fungleib.label34.caption
+msgctxt "tfreeresistance_fungleib.label34.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_fungleib.label35.caption
+msgctxt "tfreeresistance_fungleib.label35.caption"
+msgid "Angle with buttocks about 10"
+msgstr ""
+
+#: tfreeresistance_fungleib.label36.caption
+msgctxt "tfreeresistance_fungleib.label36.caption"
+msgid "Angle with buttocks about 20"
+msgstr ""
+
+#: tfreeresistance_fungleib.label37.caption
+msgctxt "tfreeresistance_fungleib.label37.caption"
+msgid "Stabiliser fins"
+msgstr ""
+
+#: tfreeresistance_fungleib.label38.caption
+msgctxt "tfreeresistance_fungleib.label38.caption"
+msgid "Dome"
+msgstr ""
+
+#: tfreeresistance_fungleib.label39.caption
+msgctxt "tfreeresistance_fungleib.label39.caption"
+msgid "Bilge keels"
+msgstr ""
+
+#: tfreeresistance_fungleib.label4.caption
+msgctxt "tfreeresistance_fungleib.label4.caption"
+msgid "Water density"
+msgstr ""
+
+#: tfreeresistance_fungleib.label5.caption
+msgctxt "tfreeresistance_fungleib.label5.caption"
+msgid "Viscosity"
+msgstr ""
+
+#: tfreeresistance_fungleib.label6.caption
+msgctxt "tfreeresistance_fungleib.label6.caption"
+msgid "Rudder behind skeg/stern"
+msgstr ""
+
+#: tfreeresistance_fungleib.label61.caption
+msgctxt "tfreeresistance_fungleib.label61.caption"
+msgid "Presence of rudders (0-No, 1-Yes):"
+msgstr ""
+
+#: tfreeresistance_fungleib.label6_1.caption
+msgctxt "tfreeresistance_fungleib.label6_1.caption"
+msgid "Time ship hull is in water, month"
+msgstr ""
+
+#: tfreeresistance_fungleib.label6_10.caption
+msgctxt "tfreeresistance_fungleib.label6_10.caption"
+msgid "Wetted area of midship, m^2"
+msgstr ""
+
+#: tfreeresistance_fungleib.label6_11.caption
+msgctxt "tfreeresistance_fungleib.label6_11.caption"
+msgid "Type of ship:"
+msgstr ""
+
+#: tfreeresistance_fungleib.label6_2.caption
+msgctxt "tfreeresistance_fungleib.label6_2.caption"
+msgid "Height of 3% wave, m "
+msgstr ""
+
+#: tfreeresistance_fungleib.label6_3.caption
+msgctxt "tfreeresistance_fungleib.label6_3.caption"
+msgid "Course angle of moving wave, degree"
+msgstr ""
+
+#: tfreeresistance_fungleib.label6_4.caption
+msgctxt "tfreeresistance_fungleib.label6_4.caption"
+msgid "Wind speed, m/s"
+msgstr ""
+
+#: tfreeresistance_fungleib.label6_5.caption
+msgctxt "tfreeresistance_fungleib.label6_5.caption"
+msgid "Course wind angle, degree"
+msgstr ""
+
+#: tfreeresistance_fungleib.label6_6.caption
+msgctxt "tfreeresistance_fungleib.label6_6.caption"
+msgid "Height of board above water, m"
+msgstr ""
+
+#: tfreeresistance_fungleib.label6_7.caption
+msgctxt "tfreeresistance_fungleib.label6_7.caption"
+msgid "Air density, kg/m^3"
+msgstr ""
+
+#: tfreeresistance_fungleib.label6_8.caption
+msgctxt "tfreeresistance_fungleib.label6_8.caption"
+msgid "Height of COG area of superstructure above waterline, m"
+msgstr ""
+
+#: tfreeresistance_fungleib.label6_9.caption
+msgctxt "tfreeresistance_fungleib.label6_9.caption"
+msgid "Depth of water, m"
+msgstr ""
+
+#: tfreeresistance_fungleib.label7.caption
+msgctxt "tfreeresistance_fungleib.label7.caption"
+msgid "Two-screw slender"
+msgstr ""
+
+#: tfreeresistance_fungleib.label8.caption
+msgctxt "tfreeresistance_fungleib.label8.caption"
+msgid "Exploitation coefficient"
+msgstr ""
+
+#: tfreeresistance_fungleib.label9.caption
+msgid "Wetted transom area, m2"
+msgstr ""
+
+#: tfreeresistance_fungleib.printbutton.caption
+msgctxt "tfreeresistance_fungleib.printbutton.caption"
+msgid "PrintButton"
+msgstr ""
+
+#: tfreeresistance_fungleib.printbutton.hint
+msgctxt "tfreeresistance_fungleib.printbutton.hint"
+msgid "Print the results of the calculation."
+msgstr ""
+
+#: tfreeresistance_fungleib.results.caption
+msgctxt "tfreeresistance_fungleib.results.caption"
+msgid "Results"
+msgstr ""
+
+#: tfreeresistance_fungleib.results2.caption
+msgctxt "tfreeresistance_fungleib.results2.caption"
+msgid "Help"
+msgstr ""
+
+#: tfreeresistance_fungleib.toolbar1.caption
+msgctxt "tfreeresistance_fungleib.toolbar1.caption"
+msgid "ToolBar1"
+msgstr ""
+
+#: tfreeresistance_fungleib.toolbutton20.hint
+msgctxt "tfreeresistance_fungleib.toolbutton20.hint"
+msgid "Start the calculation."
+msgstr ""
+
+#: tfreeresistance_fungleib.toolbutton25.hint
+msgctxt "tfreeresistance_fungleib.toolbutton25.hint"
+msgid "Close the window and save changes."
+msgstr ""
+
+#: tfreeresistance_fungleib.toolbutton7.hint
+msgctxt "tfreeresistance_fungleib.toolbutton7.hint"
+msgid "Close window without saving changes."
+msgstr ""
+
+#: tfreeresistance_fungleib._label10.caption
+msgctxt "tfreeresistance_fungleib._label10.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_fungleib._label11.caption
+msgctxt "tfreeresistance_fungleib._label11.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_fungleib._label12.caption
+msgctxt "tfreeresistance_fungleib._label12.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_fungleib._label14.caption
+msgctxt "tfreeresistance_fungleib._label14.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_fungleib._label15.caption
+msgctxt "tfreeresistance_fungleib._label15.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_fungleib._label16.caption
+msgctxt "tfreeresistance_fungleib._label16.caption"
+msgid "[%]"
+msgstr ""
+
+#: tfreeresistance_fungleib._label31.caption
+msgctxt "tfreeresistance_fungleib._label31.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_fungleib._label32.caption
+msgctxt "tfreeresistance_fungleib._label32.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_fungleib._label33.caption
+msgctxt "tfreeresistance_fungleib._label33.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_fungleib._label36.caption
+msgctxt "tfreeresistance_fungleib._label36.caption"
+msgid "E-6  m2/s"
+msgstr ""
+
+#: tfreeresistance_fungleib._label8.caption
+msgctxt "tfreeresistance_fungleib._label8.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_fungleib._label9.caption
+msgctxt "tfreeresistance_fungleib._label9.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_fungleib._toolbutton10.caption
+msgctxt "tfreeresistance_fungleib._toolbutton10.caption"
+msgid "_ToolButton10"
+msgstr ""
+
+#: tfreeresistance_fungleib._toolbutton14.caption
+msgctxt "tfreeresistance_fungleib._toolbutton14.caption"
+msgid "_ToolButton14"
+msgstr ""
+
+#: tfreeresistance_hollen.a11box.text
+msgctxt "tfreeresistance_hollen.a11box.text"
+msgid "Passenger ship and ferry"
+msgstr ""
+
+#: tfreeresistance_hollen.caption
+msgid "Resistance for sea ships by Hollenbachs method 1998"
+msgstr ""
+
+#: tfreeresistance_hollen.chart.axislist[0].title.caption
+msgctxt "tfreeresistance_hollen.chart.axislist[0].title.caption"
+msgid "Resistance [N]"
+msgstr ""
+
+#: tfreeresistance_hollen.chart.axislist[1].title.caption
+msgctxt "tfreeresistance_hollen.chart.axislist[1].title.caption"
+msgid "Speed [knots]"
+msgstr ""
+
+#: tfreeresistance_hollen.chart.axislist[2].title.caption
+msgctxt "tfreeresistance_hollen.chart.axislist[2].title.caption"
+msgid "Power [W]"
+msgstr ""
+
+#: tfreeresistance_hollen.checkbox2.caption
+msgctxt "tfreeresistance_hollen.checkbox2.caption"
+msgid "Extract data from current hull"
+msgstr ""
+
+#: tfreeresistance_hollen.data2.caption
+msgctxt "tfreeresistance_hollen.data2.caption"
+msgid "Added data"
+msgstr ""
+
+#: tfreeresistance_hollen.estimate2box.caption
+msgctxt "tfreeresistance_hollen.estimate2box.caption"
+msgid "Use calculated"
+msgstr ""
+
+#: tfreeresistance_hollen.estimatebox.caption
+msgctxt "tfreeresistance_hollen.estimatebox.caption"
+msgid "Use estimate"
+msgstr ""
+
+#: tfreeresistance_hollen.general.caption
+msgctxt "tfreeresistance_hollen.general.caption"
+msgid "General"
+msgstr ""
+
+#: tfreeresistance_hollen.groupbox1.caption
+msgctxt "tfreeresistance_hollen.groupbox1.caption"
+msgid "General"
+msgstr ""
+
+#: tfreeresistance_hollen.groupbox2.caption
+msgctxt "tfreeresistance_hollen.groupbox2.caption"
+msgid "Hull"
+msgstr "Casco"
+
+#: tfreeresistance_hollen.groupbox3.caption
+msgctxt "tfreeresistance_hollen.groupbox3.caption"
+msgid "Added data input:"
+msgstr ""
+
+#: tfreeresistance_hollen.groupbox4.caption
+msgctxt "tfreeresistance_hollen.groupbox4.caption"
+msgid "Number of appendages :"
+msgstr ""
+
+#: tfreeresistance_hollen.label1.caption
+msgctxt "tfreeresistance_hollen.label1.caption"
+msgid "Start speed"
+msgstr ""
+
+#: tfreeresistance_hollen.label10.caption
+msgctxt "tfreeresistance_hollen.label10.caption"
+msgid "Bulbous area on F.P., m^2"
+msgstr ""
+
+#: tfreeresistance_hollen.label11.caption
+msgctxt "tfreeresistance_hollen.label11.caption"
+msgid "Full Cargo or Ballast (0...1)"
+msgstr ""
+
+#: tfreeresistance_hollen.label13.caption
+msgctxt "tfreeresistance_hollen.label13.caption"
+msgid "Wetted surface"
+msgstr "Superfície molhada"
+
+#: tfreeresistance_hollen.label14.caption
+msgctxt "tfreeresistance_hollen.label14.caption"
+msgid "Form stern coefficient"
+msgstr ""
+
+#: tfreeresistance_hollen.label15.caption
+msgctxt "tfreeresistance_hollen.label15.caption"
+msgid "Number of propellers"
+msgstr ""
+
+#: tfreeresistance_hollen.label16.caption
+msgctxt "tfreeresistance_hollen.label16.caption"
+msgid "Propeller diametr, m"
+msgstr ""
+
+#: tfreeresistance_hollen.label17.caption
+msgctxt "tfreeresistance_hollen.label17.caption"
+msgid "Absolute roughness, mkm"
+msgstr ""
+
+#: tfreeresistance_hollen.label2.caption
+msgid "Estimate speed "
+msgstr ""
+
+#: tfreeresistance_hollen.label20.caption
+msgctxt "tfreeresistance_hollen.label20.caption"
+msgid "Midship draft"
+msgstr ""
+
+#: tfreeresistance_hollen.label21.caption
+msgctxt "tfreeresistance_hollen.label21.caption"
+msgid "Different"
+msgstr ""
+
+#: tfreeresistance_hollen.label22.caption
+msgctxt "tfreeresistance_hollen.label22.caption"
+msgid "Beam waterline "
+msgstr ""
+
+#: tfreeresistance_hollen.label23.caption
+msgctxt "tfreeresistance_hollen.label23.caption"
+msgid "Length waterline"
+msgstr ""
+
+#: tfreeresistance_hollen.label24.caption
+msgctxt "tfreeresistance_hollen.label24.caption"
+msgid "Prismatic coefficient "
+msgstr ""
+
+#: tfreeresistance_hollen.label25.caption
+msgctxt "tfreeresistance_hollen.label25.caption"
+msgid "LCB"
+msgstr ""
+
+#: tfreeresistance_hollen.label26.caption
+msgctxt "tfreeresistance_hollen.label26.caption"
+msgid "Displacement"
+msgstr "Deslocamento"
+
+#: tfreeresistance_hollen.label27.caption
+msgctxt "tfreeresistance_hollen.label27.caption"
+msgid "Length over surface"
+msgstr ""
+
+#: tfreeresistance_hollen.label28.caption
+msgctxt "tfreeresistance_hollen.label28.caption"
+msgid "Skeg"
+msgstr ""
+
+#: tfreeresistance_hollen.label281.caption
+msgctxt "tfreeresistance_hollen.label281.caption"
+msgid "Keel and skeg:"
+msgstr ""
+
+#: tfreeresistance_hollen.label29.caption
+msgctxt "tfreeresistance_hollen.label29.caption"
+msgid "Bilge keels"
+msgstr ""
+
+#: tfreeresistance_hollen.label3.caption
+msgctxt "tfreeresistance_hollen.label3.caption"
+msgid "Maximal speed"
+msgstr ""
+
+#: tfreeresistance_hollen.label30.caption
+msgctxt "tfreeresistance_hollen.label30.caption"
+msgid "Shaft brackets"
+msgstr ""
+
+#: tfreeresistance_hollen.label31.caption
+msgctxt "tfreeresistance_hollen.label31.caption"
+msgid "Strut bossing"
+msgstr ""
+
+#: tfreeresistance_hollen.label32.caption
+msgctxt "tfreeresistance_hollen.label32.caption"
+msgid "Hull bossing"
+msgstr ""
+
+#: tfreeresistance_hollen.label33.caption
+msgctxt "tfreeresistance_hollen.label33.caption"
+msgid "Exposed shafts:"
+msgstr ""
+
+#: tfreeresistance_hollen.label34.caption
+msgctxt "tfreeresistance_hollen.label34.caption"
+msgid "t/m^3"
+msgstr ""
+
+#: tfreeresistance_hollen.label35.caption
+msgctxt "tfreeresistance_hollen.label35.caption"
+msgid "Angle with buttocks about 10"
+msgstr ""
+
+#: tfreeresistance_hollen.label36.caption
+msgctxt "tfreeresistance_hollen.label36.caption"
+msgid "Angle with buttocks about 20"
+msgstr ""
+
+#: tfreeresistance_hollen.label37.caption
+msgctxt "tfreeresistance_hollen.label37.caption"
+msgid "Stabiliser fins"
+msgstr ""
+
+#: tfreeresistance_hollen.label38.caption
+msgctxt "tfreeresistance_hollen.label38.caption"
+msgid "Dome"
+msgstr ""
+
+#: tfreeresistance_hollen.label4.caption
+msgctxt "tfreeresistance_hollen.label4.caption"
+msgid "Water density"
+msgstr ""
+
+#: tfreeresistance_hollen.label5.caption
+msgctxt "tfreeresistance_hollen.label5.caption"
+msgid "Viscosity"
+msgstr ""
+
+#: tfreeresistance_hollen.label6.caption
+msgctxt "tfreeresistance_hollen.label6.caption"
+msgid "Rudder behind skeg/stern"
+msgstr ""
+
+#: tfreeresistance_hollen.label61.caption
+msgctxt "tfreeresistance_hollen.label61.caption"
+msgid "Presence of rudders (0-No, 1-Yes):"
+msgstr ""
+
+#: tfreeresistance_hollen.label6_1.caption
+msgctxt "tfreeresistance_hollen.label6_1.caption"
+msgid "Time ship hull is in water, month"
+msgstr ""
+
+#: tfreeresistance_hollen.label6_10.caption
+msgctxt "tfreeresistance_hollen.label6_10.caption"
+msgid "Wetted area of midship, m^2"
+msgstr ""
+
+#: tfreeresistance_hollen.label6_11.caption
+msgctxt "tfreeresistance_hollen.label6_11.caption"
+msgid "Type of ship:"
+msgstr ""
+
+#: tfreeresistance_hollen.label6_2.caption
+msgctxt "tfreeresistance_hollen.label6_2.caption"
+msgid "Height of 3% wave, m "
+msgstr ""
+
+#: tfreeresistance_hollen.label6_3.caption
+msgctxt "tfreeresistance_hollen.label6_3.caption"
+msgid "Course angle of moving wave, degree"
+msgstr ""
+
+#: tfreeresistance_hollen.label6_4.caption
+msgctxt "tfreeresistance_hollen.label6_4.caption"
+msgid "Wind speed, m/s"
+msgstr ""
+
+#: tfreeresistance_hollen.label6_5.caption
+msgctxt "tfreeresistance_hollen.label6_5.caption"
+msgid "Course wind angle, degree"
+msgstr ""
+
+#: tfreeresistance_hollen.label6_6.caption
+msgctxt "tfreeresistance_hollen.label6_6.caption"
+msgid "Height of board above water, m"
+msgstr ""
+
+#: tfreeresistance_hollen.label6_7.caption
+msgctxt "tfreeresistance_hollen.label6_7.caption"
+msgid "Air density, kg/m^3"
+msgstr ""
+
+#: tfreeresistance_hollen.label6_8.caption
+msgctxt "tfreeresistance_hollen.label6_8.caption"
+msgid "Height of COG area of superstructure above waterline, m"
+msgstr ""
+
+#: tfreeresistance_hollen.label6_9.caption
+msgctxt "tfreeresistance_hollen.label6_9.caption"
+msgid "Depth of water, m"
+msgstr ""
+
+#: tfreeresistance_hollen.label7.caption
+msgctxt "tfreeresistance_hollen.label7.caption"
+msgid "Two-screw slender"
+msgstr ""
+
+#: tfreeresistance_hollen.label8.caption
+msgctxt "tfreeresistance_hollen.label8.caption"
+msgid "Exploitation coefficient"
+msgstr ""
+
+#: tfreeresistance_hollen.label9.caption
+msgctxt "tfreeresistance_hollen.label9.caption"
+msgid "Number of thrusters (0...2)"
+msgstr ""
+
+#: tfreeresistance_hollen.printbutton.caption
+msgctxt "tfreeresistance_hollen.printbutton.caption"
+msgid "PrintButton"
+msgstr ""
+
+#: tfreeresistance_hollen.printbutton.hint
+msgctxt "tfreeresistance_hollen.printbutton.hint"
+msgid "Print the results of the calculation."
+msgstr ""
+
+#: tfreeresistance_hollen.results.caption
+msgctxt "tfreeresistance_hollen.results.caption"
+msgid "Results"
+msgstr ""
+
+#: tfreeresistance_hollen.results2.caption
+msgctxt "tfreeresistance_hollen.results2.caption"
+msgid "Help"
+msgstr ""
+
+#: tfreeresistance_hollen.toolbar1.caption
+msgctxt "tfreeresistance_hollen.toolbar1.caption"
+msgid "ToolBar1"
+msgstr ""
+
+#: tfreeresistance_hollen.toolbutton20.hint
+msgctxt "tfreeresistance_hollen.toolbutton20.hint"
+msgid "Start the calculation."
+msgstr ""
+
+#: tfreeresistance_hollen.toolbutton25.hint
+msgctxt "tfreeresistance_hollen.toolbutton25.hint"
+msgid "Close the window and save changes."
+msgstr ""
+
+#: tfreeresistance_hollen.toolbutton7.hint
+msgctxt "tfreeresistance_hollen.toolbutton7.hint"
+msgid "Close window without saving changes."
+msgstr ""
+
+#: tfreeresistance_hollen._label10.caption
+msgctxt "tfreeresistance_hollen._label10.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_hollen._label11.caption
+msgctxt "tfreeresistance_hollen._label11.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_hollen._label12.caption
+msgctxt "tfreeresistance_hollen._label12.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_hollen._label14.caption
+msgctxt "tfreeresistance_hollen._label14.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_hollen._label15.caption
+msgctxt "tfreeresistance_hollen._label15.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_hollen._label16.caption
+msgctxt "tfreeresistance_hollen._label16.caption"
+msgid "[%]"
+msgstr ""
+
+#: tfreeresistance_hollen._label31.caption
+msgctxt "tfreeresistance_hollen._label31.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_hollen._label32.caption
+msgctxt "tfreeresistance_hollen._label32.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_hollen._label33.caption
+msgctxt "tfreeresistance_hollen._label33.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_hollen._label36.caption
+msgctxt "tfreeresistance_hollen._label36.caption"
+msgid "m^2/s"
+msgstr ""
+
+#: tfreeresistance_hollen._label8.caption
+msgctxt "tfreeresistance_hollen._label8.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_hollen._label9.caption
+msgctxt "tfreeresistance_hollen._label9.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_hollen._toolbutton10.caption
+msgctxt "tfreeresistance_hollen._toolbutton10.caption"
+msgid "_ToolButton10"
+msgstr ""
+
+#: tfreeresistance_hollen._toolbutton14.caption
+msgctxt "tfreeresistance_hollen._toolbutton14.caption"
+msgid "_ToolButton14"
+msgstr ""
+
+#: tfreeresistance_holtr.a11box.text
+msgctxt "tfreeresistance_holtr.a11box.text"
+msgid "Passenger ship and ferry"
+msgstr ""
+
+#: tfreeresistance_holtr.caption
+msgid "Resistance for sea ships"
+msgstr ""
+
+#: tfreeresistance_holtr.chart.axislist[0].title.caption
+msgctxt "tfreeresistance_holtr.chart.axislist[0].title.caption"
+msgid "Resistance [N]"
+msgstr ""
+
+#: tfreeresistance_holtr.chart.axislist[1].title.caption
+msgid "Speed [m/s]"
+msgstr ""
+
+#: tfreeresistance_holtr.chart.axislist[2].title.caption
+msgctxt "tfreeresistance_holtr.chart.axislist[2].title.caption"
+msgid "Power [W]"
+msgstr ""
+
+#: tfreeresistance_holtr.checkbox2.caption
+msgctxt "tfreeresistance_holtr.checkbox2.caption"
+msgid "Extract data from current hull"
+msgstr ""
+
+#: tfreeresistance_holtr.data2.caption
+msgctxt "tfreeresistance_holtr.data2.caption"
+msgid "Added data"
+msgstr ""
+
+#: tfreeresistance_holtr.estimate2box.caption
+msgctxt "tfreeresistance_holtr.estimate2box.caption"
+msgid "Use calculated"
+msgstr ""
+
+#: tfreeresistance_holtr.estimate3box.caption
+msgid "Add calculated by Holtrop-1984 method"
+msgstr ""
+
+#: tfreeresistance_holtr.estimate4box.caption
+msgid "Extract half entrance angle from model - Ie"
+msgstr ""
+
+#: tfreeresistance_holtr.estimatebox.caption
+msgctxt "tfreeresistance_holtr.estimatebox.caption"
+msgid "Use estimate"
+msgstr ""
+
+#: tfreeresistance_holtr.general.caption
+msgctxt "tfreeresistance_holtr.general.caption"
+msgid "General"
+msgstr ""
+
+#: tfreeresistance_holtr.groupbox1.caption
+msgctxt "tfreeresistance_holtr.groupbox1.caption"
+msgid "General"
+msgstr ""
+
+#: tfreeresistance_holtr.groupbox2.caption
+msgctxt "tfreeresistance_holtr.groupbox2.caption"
+msgid "Hull"
+msgstr "Casco"
+
+#: tfreeresistance_holtr.groupbox3.caption
+msgctxt "tfreeresistance_holtr.groupbox3.caption"
+msgid "Added data input:"
+msgstr ""
+
+#: tfreeresistance_holtr.groupbox4.caption
+msgid "Appendage areas input, [m^2]:"
+msgstr ""
+
+#: tfreeresistance_holtr.label1.caption
+msgctxt "tfreeresistance_holtr.label1.caption"
+msgid "Start speed"
+msgstr ""
+
+#: tfreeresistance_holtr.label10.caption
+msgctxt "tfreeresistance_holtr.label10.caption"
+msgid "Bulbous area on F.P., m^2"
+msgstr ""
+
+#: tfreeresistance_holtr.label11.caption
+msgid "Z COG of bulbous area, m"
+msgstr ""
+
+#: tfreeresistance_holtr.label13.caption
+msgctxt "tfreeresistance_holtr.label13.caption"
+msgid "Wetted surface"
+msgstr "Superfície molhada"
+
+#: tfreeresistance_holtr.label14.caption
+msgctxt "tfreeresistance_holtr.label14.caption"
+msgid "Form stern coefficient"
+msgstr ""
+
+#: tfreeresistance_holtr.label15.caption
+msgctxt "tfreeresistance_holtr.label15.caption"
+msgid "Number of propellers"
+msgstr ""
+
+#: tfreeresistance_holtr.label16.caption
+msgctxt "tfreeresistance_holtr.label16.caption"
+msgid "Propeller diametr, m"
+msgstr ""
+
+#: tfreeresistance_holtr.label17.caption
+msgctxt "tfreeresistance_holtr.label17.caption"
+msgid "Absolute roughness, mkm"
+msgstr ""
+
+#: tfreeresistance_holtr.label2.caption
+msgctxt "tfreeresistance_holtr.label2.caption"
+msgid "End speed "
+msgstr ""
+
+#: tfreeresistance_holtr.label20.caption
+msgctxt "tfreeresistance_holtr.label20.caption"
+msgid "Midship draft"
+msgstr ""
+
+#: tfreeresistance_holtr.label21.caption
+msgctxt "tfreeresistance_holtr.label21.caption"
+msgid "Different"
+msgstr ""
+
+#: tfreeresistance_holtr.label22.caption
+msgctxt "tfreeresistance_holtr.label22.caption"
+msgid "Beam waterline "
+msgstr ""
+
+#: tfreeresistance_holtr.label23.caption
+msgctxt "tfreeresistance_holtr.label23.caption"
+msgid "Length waterline"
+msgstr ""
+
+#: tfreeresistance_holtr.label24.caption
+msgctxt "tfreeresistance_holtr.label24.caption"
+msgid "Prismatic coefficient "
+msgstr ""
+
+#: tfreeresistance_holtr.label25.caption
+msgctxt "tfreeresistance_holtr.label25.caption"
+msgid "LCB"
+msgstr ""
+
+#: tfreeresistance_holtr.label26.caption
+msgctxt "tfreeresistance_holtr.label26.caption"
+msgid "Displacement"
+msgstr "Deslocamento"
+
+#: tfreeresistance_holtr.label27.caption
+msgctxt "tfreeresistance_holtr.label27.caption"
+msgid "Waterplane area"
+msgstr ""
+
+#: tfreeresistance_holtr.label28.caption
+msgctxt "tfreeresistance_holtr.label28.caption"
+msgid "Skeg"
+msgstr ""
+
+#: tfreeresistance_holtr.label281.caption
+msgid "Keel and skeg area, [m^2]:"
+msgstr ""
+
+#: tfreeresistance_holtr.label29.caption
+msgctxt "tfreeresistance_holtr.label29.caption"
+msgid "Bilge keels"
+msgstr ""
+
+#: tfreeresistance_holtr.label3.caption
+msgctxt "tfreeresistance_holtr.label3.caption"
+msgid "Step"
+msgstr ""
+
+#: tfreeresistance_holtr.label30.caption
+msgctxt "tfreeresistance_holtr.label30.caption"
+msgid "Shaft brackets"
+msgstr ""
+
+#: tfreeresistance_holtr.label31.caption
+msgctxt "tfreeresistance_holtr.label31.caption"
+msgid "Strut bossing"
+msgstr ""
+
+#: tfreeresistance_holtr.label32.caption
+msgctxt "tfreeresistance_holtr.label32.caption"
+msgid "Hull bossing"
+msgstr ""
+
+#: tfreeresistance_holtr.label33.caption
+msgid "Exposed shafts, [m^2]:"
+msgstr ""
+
+#: tfreeresistance_holtr.label34.caption
+msgctxt "tfreeresistance_holtr.label34.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_holtr.label35.caption
+msgctxt "tfreeresistance_holtr.label35.caption"
+msgid "Angle with buttocks about 10"
+msgstr ""
+
+#: tfreeresistance_holtr.label36.caption
+msgctxt "tfreeresistance_holtr.label36.caption"
+msgid "Angle with buttocks about 20"
+msgstr ""
+
+#: tfreeresistance_holtr.label37.caption
+msgctxt "tfreeresistance_holtr.label37.caption"
+msgid "Stabiliser fins"
+msgstr ""
+
+#: tfreeresistance_holtr.label38.caption
+msgctxt "tfreeresistance_holtr.label38.caption"
+msgid "Dome"
+msgstr ""
+
+#: tfreeresistance_holtr.label4.caption
+msgctxt "tfreeresistance_holtr.label4.caption"
+msgid "Water density"
+msgstr ""
+
+#: tfreeresistance_holtr.label5.caption
+msgctxt "tfreeresistance_holtr.label5.caption"
+msgid "Viscosity"
+msgstr ""
+
+#: tfreeresistance_holtr.label6.caption
+msgctxt "tfreeresistance_holtr.label6.caption"
+msgid "Rudder behind skeg/stern"
+msgstr ""
+
+#: tfreeresistance_holtr.label61.caption
+msgid "Rudders area, [m^2]:"
+msgstr ""
+
+#: tfreeresistance_holtr.label6_1.caption
+msgctxt "tfreeresistance_holtr.label6_1.caption"
+msgid "Time ship hull is in water, month"
+msgstr ""
+
+#: tfreeresistance_holtr.label6_10.caption
+msgctxt "tfreeresistance_holtr.label6_10.caption"
+msgid "Wetted area of midship, m^2"
+msgstr ""
+
+#: tfreeresistance_holtr.label6_11.caption
+msgctxt "tfreeresistance_holtr.label6_11.caption"
+msgid "Type of ship:"
+msgstr ""
+
+#: tfreeresistance_holtr.label6_12.caption
+msgctxt "tfreeresistance_holtr.label6_12.caption"
+msgid "Type of ship:"
+msgstr ""
+
+#: tfreeresistance_holtr.label6_2.caption
+msgctxt "tfreeresistance_holtr.label6_2.caption"
+msgid "Height of 3% wave, m "
+msgstr ""
+
+#: tfreeresistance_holtr.label6_3.caption
+msgctxt "tfreeresistance_holtr.label6_3.caption"
+msgid "Course angle of moving wave, degree"
+msgstr ""
+
+#: tfreeresistance_holtr.label6_4.caption
+msgctxt "tfreeresistance_holtr.label6_4.caption"
+msgid "Wind speed, m/s"
+msgstr ""
+
+#: tfreeresistance_holtr.label6_5.caption
+msgctxt "tfreeresistance_holtr.label6_5.caption"
+msgid "Course wind angle, degree"
+msgstr ""
+
+#: tfreeresistance_holtr.label6_6.caption
+msgctxt "tfreeresistance_holtr.label6_6.caption"
+msgid "Height of board above water, m"
+msgstr ""
+
+#: tfreeresistance_holtr.label6_7.caption
+msgctxt "tfreeresistance_holtr.label6_7.caption"
+msgid "Air density, kg/m^3"
+msgstr ""
+
+#: tfreeresistance_holtr.label6_8.caption
+msgctxt "tfreeresistance_holtr.label6_8.caption"
+msgid "Height of COG area of superstructure above waterline, m"
+msgstr ""
+
+#: tfreeresistance_holtr.label6_9.caption
+msgctxt "tfreeresistance_holtr.label6_9.caption"
+msgid "Depth of water, m"
+msgstr ""
+
+#: tfreeresistance_holtr.label7.caption
+msgctxt "tfreeresistance_holtr.label7.caption"
+msgid "Two-screw slender"
+msgstr ""
+
+#: tfreeresistance_holtr.label8.caption
+msgctxt "tfreeresistance_holtr.label8.caption"
+msgid "Sea margin coefficient"
+msgstr ""
+
+#: tfreeresistance_holtr.label9.caption
+msgid "Transom wetted area, m^2"
+msgstr ""
+
+#: tfreeresistance_holtr.results.caption
+msgctxt "tfreeresistance_holtr.results.caption"
+msgid "Results"
+msgstr ""
+
+#: tfreeresistance_holtr.results2.caption
+msgctxt "tfreeresistance_holtr.results2.caption"
+msgid "Help"
+msgstr ""
+
+#: tfreeresistance_holtr.tbcalculate.hint
+msgctxt "tfreeresistance_holtr.tbcalculate.hint"
+msgid "Start the calculation."
+msgstr ""
+
+#: tfreeresistance_holtr.tbclose.hint
+msgctxt "tfreeresistance_holtr.tbclose.hint"
+msgid "Close window without saving changes."
+msgstr ""
+
+#: tfreeresistance_holtr.tbclosesave.hint
+msgctxt "tfreeresistance_holtr.tbclosesave.hint"
+msgid "Close the window and save changes."
+msgstr ""
+
+#: tfreeresistance_holtr.tbprint.caption
+msgid "tbPrint"
+msgstr ""
+
+#: tfreeresistance_holtr.tbprint.hint
+msgctxt "tfreeresistance_holtr.tbprint.hint"
+msgid "Print the results of the calculation."
+msgstr ""
+
+#: tfreeresistance_holtr.toolbar1.caption
+msgctxt "tfreeresistance_holtr.toolbar1.caption"
+msgid "ToolBar1"
+msgstr ""
+
+#: tfreeresistance_holtr._label10.caption
+msgctxt "tfreeresistance_holtr._label10.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_holtr._label11.caption
+msgctxt "tfreeresistance_holtr._label11.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_holtr._label12.caption
+msgctxt "tfreeresistance_holtr._label12.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_holtr._label14.caption
+msgctxt "tfreeresistance_holtr._label14.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_holtr._label15.caption
+msgctxt "tfreeresistance_holtr._label15.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_holtr._label16.caption
+msgctxt "tfreeresistance_holtr._label16.caption"
+msgid "[%]"
+msgstr ""
+
+#: tfreeresistance_holtr._label31.caption
+msgctxt "tfreeresistance_holtr._label31.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_holtr._label32.caption
+msgctxt "tfreeresistance_holtr._label32.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_holtr._label33.caption
+msgctxt "tfreeresistance_holtr._label33.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_holtr._label36.caption
+msgctxt "tfreeresistance_holtr._label36.caption"
+msgid "E-6  m2/s"
+msgstr ""
+
+#: tfreeresistance_holtr._label8.caption
+msgctxt "tfreeresistance_holtr._label8.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_holtr._label9.caption
+msgctxt "tfreeresistance_holtr._label9.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_holtr._toolbutton10.caption
+msgctxt "tfreeresistance_holtr._toolbutton10.caption"
+msgid "_ToolButton10"
+msgstr ""
+
+#: tfreeresistance_holtr._toolbutton14.caption
+msgctxt "tfreeresistance_holtr._toolbutton14.caption"
+msgid "_ToolButton14"
+msgstr ""
+
+#: tfreeresistance_kaper.caption
+msgid "Kaper resistance calculation."
+msgstr ""
+
+#: tfreeresistance_kaper.chart.axislist[0].title.caption
+msgctxt "tfreeresistance_kaper.chart.axislist[0].title.caption"
+msgid "Resistance [Lbs]"
+msgstr ""
+
+#: tfreeresistance_kaper.chart.axislist[1].title.caption
+msgctxt "tfreeresistance_kaper.chart.axislist[1].title.caption"
+msgid "Speed [knots]"
+msgstr ""
+
+#: tfreeresistance_kaper.checkbox2.caption
+msgctxt "tfreeresistance_kaper.checkbox2.caption"
+msgid "Extract data from current hull"
+msgstr ""
+
+#: tfreeresistance_kaper.edit10.hint
+msgid "0.00 .. 0.04"
+msgstr ""
+
+#: tfreeresistance_kaper.edit6.hint
+msgid "0.48 .. 0.64"
+msgstr ""
+
+#: tfreeresistance_kaper.label10.caption
+msgctxt "tfreeresistance_kaper.label10.caption"
+msgid "[-]"
+msgstr ""
+
+#: tfreeresistance_kaper.label11.caption
+msgctxt "tfreeresistance_kaper.label11.caption"
+msgid "[-]"
+msgstr ""
+
+#: tfreeresistance_kaper.label13.caption
+msgctxt "tfreeresistance_kaper.label13.caption"
+msgid "Displacement"
+msgstr "Deslocamento"
+
+#: tfreeresistance_kaper.label14.caption
+msgctxt "tfreeresistance_kaper.label14.caption"
+msgid "[-]"
+msgstr ""
+
+#: tfreeresistance_kaper.label15.caption
+msgid "Half entrance angle"
+msgstr ""
+
+#: tfreeresistance_kaper.label16.caption
+msgctxt "tfreeresistance_kaper.label16.caption"
+msgid "[-]"
+msgstr ""
+
+#: tfreeresistance_kaper.label17.caption
+msgctxt "tfreeresistance_kaper.label17.caption"
+msgid "LCB"
+msgstr ""
+
+#: tfreeresistance_kaper.label19.caption
+msgid "Subm. transom ratio"
+msgstr ""
+
+#: tfreeresistance_kaper.label2.caption
+msgctxt "tfreeresistance_kaper.label2.caption"
+msgid "Length waterline"
+msgstr ""
+
+#: tfreeresistance_kaper.label3.caption
+msgctxt "tfreeresistance_kaper.label3.caption"
+msgid "Beam waterline"
+msgstr ""
+
+#: tfreeresistance_kaper.label4.caption
+msgctxt "tfreeresistance_kaper.label4.caption"
+msgid "Draft"
+msgstr ""
+
+#: tfreeresistance_kaper.label6.caption
+msgctxt "tfreeresistance_kaper.label6.caption"
+msgid "Wetted surface area"
+msgstr "Área de superfície molhada"
+
+#: tfreeresistance_kaper.label7.caption
+msgctxt "tfreeresistance_kaper.label7.caption"
+msgid "[-]"
+msgstr ""
+
+#: tfreeresistance_kaper.label8.caption
+msgctxt "tfreeresistance_kaper.label8.caption"
+msgid "Cp"
+msgstr ""
+
+#: tfreeresistance_kaper.label9.caption
+msgctxt "tfreeresistance_kaper.label9.caption"
+msgid "[-]"
+msgstr ""
+
+#: tfreeresistance_kaper.printbutton.caption
+msgctxt "tfreeresistance_kaper.printbutton.caption"
+msgid "PrintButton"
+msgstr ""
+
+#: tfreeresistance_kaper.printbutton.hint
+msgctxt "tfreeresistance_kaper.printbutton.hint"
+msgid "Print the results of the calculation."
+msgstr ""
+
+#: tfreeresistance_kaper.tabsheet1.caption
+msgctxt "tfreeresistance_kaper.tabsheet1.caption"
+msgid "General"
+msgstr ""
+
+#: tfreeresistance_kaper.tabsheet2.caption
+msgctxt "tfreeresistance_kaper.tabsheet2.caption"
+msgid "Results"
+msgstr ""
+
+#: tfreeresistance_kaper.toolbar1.caption
+msgctxt "tfreeresistance_kaper.toolbar1.caption"
+msgid "ToolBar1"
+msgstr ""
+
+#: tfreeresistance_kaper.toolbutton25.hint
+msgctxt "tfreeresistance_kaper.toolbutton25.hint"
+msgid "Close the window and save changes."
+msgstr ""
+
+#: tfreeresistance_kaper.toolbutton7.hint
+msgctxt "tfreeresistance_kaper.toolbutton7.hint"
+msgid "Close window without saving changes."
+msgstr ""
+
+#: tfreeresistance_kaper._toolbutton10.caption
+msgctxt "tfreeresistance_kaper._toolbutton10.caption"
+msgid "_ToolButton10"
+msgstr ""
+
+#: tfreeresistance_kaper._toolbutton14.caption
+msgctxt "tfreeresistance_kaper._toolbutton14.caption"
+msgid "_ToolButton14"
+msgstr ""
+
+#: tfreeresistance_mh.a11box.text
+msgctxt "tfreeresistance_mh.a11box.text"
+msgid "Passenger ship and ferry"
+msgstr ""
+
+#: tfreeresistance_mh.caption
+msgid "Resistance for multihull ships"
+msgstr ""
+
+#: tfreeresistance_mh.chart.axislist[0].title.caption
+msgctxt "tfreeresistance_mh.chart.axislist[0].title.caption"
+msgid "Resistance [kN]"
+msgstr "Resistência [kN]"
+
+#: tfreeresistance_mh.chart.axislist[1].title.caption
+msgctxt "tfreeresistance_mh.chart.axislist[1].title.caption"
+msgid "Speed [knots]"
+msgstr ""
+
+#: tfreeresistance_mh.chart.axislist[2].title.caption
+msgctxt "tfreeresistance_mh.chart.axislist[2].title.caption"
+msgid "Power [kW]"
+msgstr ""
+
+#: tfreeresistance_mh.checkbox2.caption
+msgctxt "tfreeresistance_mh.checkbox2.caption"
+msgid "Extract data from current hull"
+msgstr ""
+
+#: tfreeresistance_mh.combobox.text
+msgid "model tests"
+msgstr ""
+
+#: tfreeresistance_mh.data2.caption
+msgctxt "tfreeresistance_mh.data2.caption"
+msgid "Added data"
+msgstr ""
+
+#: tfreeresistance_mh.estimate2box.caption
+msgctxt "tfreeresistance_mh.estimate2box.caption"
+msgid "Use calculated"
+msgstr ""
+
+#: tfreeresistance_mh.estimatebox.caption
+msgctxt "tfreeresistance_mh.estimatebox.caption"
+msgid "Use estimate"
+msgstr ""
+
+#: tfreeresistance_mh.general.caption
+msgctxt "tfreeresistance_mh.general.caption"
+msgid "General"
+msgstr ""
+
+#: tfreeresistance_mh.groupbox1.caption
+msgctxt "tfreeresistance_mh.groupbox1.caption"
+msgid "General"
+msgstr ""
+
+#: tfreeresistance_mh.groupbox2.caption
+msgctxt "tfreeresistance_mh.groupbox2.caption"
+msgid "Hull"
+msgstr "Casco"
+
+#: tfreeresistance_mh.groupbox3.caption
+msgctxt "tfreeresistance_mh.groupbox3.caption"
+msgid "Added data input:"
+msgstr ""
+
+#: tfreeresistance_mh.groupbox4.caption
+msgctxt "tfreeresistance_mh.groupbox4.caption"
+msgid "Number of appendages :"
+msgstr ""
+
+#: tfreeresistance_mh.label1.caption
+msgctxt "tfreeresistance_mh.label1.caption"
+msgid "Start speed"
+msgstr ""
+
+#: tfreeresistance_mh.label10.caption
+msgctxt "tfreeresistance_mh.label10.caption"
+msgid "Type of forward stern"
+msgstr ""
+
+#: tfreeresistance_mh.label11.caption
+msgctxt "tfreeresistance_mh.label11.caption"
+msgid "Type of after stern"
+msgstr ""
+
+#: tfreeresistance_mh.label13.caption
+msgctxt "tfreeresistance_mh.label13.caption"
+msgid "Wetted surface"
+msgstr "Superfície molhada"
+
+#: tfreeresistance_mh.label15.caption
+msgctxt "tfreeresistance_mh.label15.caption"
+msgid "Number of propellers"
+msgstr ""
+
+#: tfreeresistance_mh.label16.caption
+msgctxt "tfreeresistance_mh.label16.caption"
+msgid "Propeller diametr, m"
+msgstr ""
+
+#: tfreeresistance_mh.label17.caption
+msgctxt "tfreeresistance_mh.label17.caption"
+msgid "Absolute roughness, mkm"
+msgstr ""
+
+#: tfreeresistance_mh.label19.caption
+msgid "Calculation by the method:"
+msgstr ""
+
+#: tfreeresistance_mh.label2.caption
+msgctxt "tfreeresistance_mh.label2.caption"
+msgid "End speed "
+msgstr ""
+
+#: tfreeresistance_mh.label20.caption
+msgctxt "tfreeresistance_mh.label20.caption"
+msgid "Midship draft"
+msgstr ""
+
+#: tfreeresistance_mh.label21.caption
+msgctxt "tfreeresistance_mh.label21.caption"
+msgid "Different"
+msgstr ""
+
+#: tfreeresistance_mh.label22.caption
+msgctxt "tfreeresistance_mh.label22.caption"
+msgid "Beam waterline "
+msgstr ""
+
+#: tfreeresistance_mh.label23.caption
+msgctxt "tfreeresistance_mh.label23.caption"
+msgid "Length waterline"
+msgstr ""
+
+#: tfreeresistance_mh.label24.caption
+msgctxt "tfreeresistance_mh.label24.caption"
+msgid "Prismatic coefficient "
+msgstr ""
+
+#: tfreeresistance_mh.label25.caption
+msgctxt "tfreeresistance_mh.label25.caption"
+msgid "LCB"
+msgstr ""
+
+#: tfreeresistance_mh.label26.caption
+msgctxt "tfreeresistance_mh.label26.caption"
+msgid "Displacement"
+msgstr "Deslocamento"
+
+#: tfreeresistance_mh.label27.caption
+msgctxt "tfreeresistance_mh.label27.caption"
+msgid "Waterplane area"
+msgstr ""
+
+#: tfreeresistance_mh.label281.caption
+msgctxt "tfreeresistance_mh.label281.caption"
+msgid "Keel and skeg:"
+msgstr ""
+
+#: tfreeresistance_mh.label3.caption
+msgctxt "tfreeresistance_mh.label3.caption"
+msgid "Step"
+msgstr ""
+
+#: tfreeresistance_mh.label30.caption
+msgctxt "tfreeresistance_mh.label30.caption"
+msgid "Shaft brackets"
+msgstr ""
+
+#: tfreeresistance_mh.label31.caption
+msgctxt "tfreeresistance_mh.label31.caption"
+msgid "Strut bossing"
+msgstr ""
+
+#: tfreeresistance_mh.label32.caption
+msgctxt "tfreeresistance_mh.label32.caption"
+msgid "Hull bossing"
+msgstr ""
+
+#: tfreeresistance_mh.label33.caption
+msgctxt "tfreeresistance_mh.label33.caption"
+msgid "Exposed shafts:"
+msgstr ""
+
+#: tfreeresistance_mh.label34.caption
+msgctxt "tfreeresistance_mh.label34.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_mh.label35.caption
+msgctxt "tfreeresistance_mh.label35.caption"
+msgid "Angle with buttocks about 10"
+msgstr ""
+
+#: tfreeresistance_mh.label36.caption
+msgctxt "tfreeresistance_mh.label36.caption"
+msgid "Angle with buttocks about 20"
+msgstr ""
+
+#: tfreeresistance_mh.label37.caption
+msgctxt "tfreeresistance_mh.label37.caption"
+msgid "Stabiliser fins"
+msgstr ""
+
+#: tfreeresistance_mh.label38.caption
+msgctxt "tfreeresistance_mh.label38.caption"
+msgid "Dome"
+msgstr ""
+
+#: tfreeresistance_mh.label39.caption
+msgctxt "tfreeresistance_mh.label39.caption"
+msgid "Skeg"
+msgstr ""
+
+#: tfreeresistance_mh.label4.caption
+msgctxt "tfreeresistance_mh.label4.caption"
+msgid "Water density"
+msgstr ""
+
+#: tfreeresistance_mh.label40.caption
+msgctxt "tfreeresistance_mh.label40.caption"
+msgid "Bilge keels"
+msgstr ""
+
+#: tfreeresistance_mh.label5.caption
+msgctxt "tfreeresistance_mh.label5.caption"
+msgid "Viscosity"
+msgstr ""
+
+#: tfreeresistance_mh.label6.caption
+msgctxt "tfreeresistance_mh.label6.caption"
+msgid "Rudder behind skeg/stern"
+msgstr ""
+
+#: tfreeresistance_mh.label61.caption
+msgctxt "tfreeresistance_mh.label61.caption"
+msgid "Presence of rudders (0-No, 1-Yes):"
+msgstr ""
+
+#: tfreeresistance_mh.label6_1.caption
+msgctxt "tfreeresistance_mh.label6_1.caption"
+msgid "Time ship hull is in water, month"
+msgstr ""
+
+#: tfreeresistance_mh.label6_10.caption
+msgctxt "tfreeresistance_mh.label6_10.caption"
+msgid "Wetted area of midship, m^2"
+msgstr ""
+
+#: tfreeresistance_mh.label6_11.caption
+msgctxt "tfreeresistance_mh.label6_11.caption"
+msgid "Type of ship:"
+msgstr ""
+
+#: tfreeresistance_mh.label6_2.caption
+msgctxt "tfreeresistance_mh.label6_2.caption"
+msgid "Height of 3% wave, m "
+msgstr ""
+
+#: tfreeresistance_mh.label6_3.caption
+msgctxt "tfreeresistance_mh.label6_3.caption"
+msgid "Course angle of moving wave, degree"
+msgstr ""
+
+#: tfreeresistance_mh.label6_4.caption
+msgctxt "tfreeresistance_mh.label6_4.caption"
+msgid "Wind speed, m/s"
+msgstr ""
+
+#: tfreeresistance_mh.label6_5.caption
+msgctxt "tfreeresistance_mh.label6_5.caption"
+msgid "Course wind angle, degree"
+msgstr ""
+
+#: tfreeresistance_mh.label6_6.caption
+msgctxt "tfreeresistance_mh.label6_6.caption"
+msgid "Height of board above water, m"
+msgstr ""
+
+#: tfreeresistance_mh.label6_7.caption
+msgctxt "tfreeresistance_mh.label6_7.caption"
+msgid "Air density, kg/m^3"
+msgstr ""
+
+#: tfreeresistance_mh.label6_8.caption
+msgctxt "tfreeresistance_mh.label6_8.caption"
+msgid "Height of COG area of superstructure above waterline, m"
+msgstr ""
+
+#: tfreeresistance_mh.label6_9.caption
+msgctxt "tfreeresistance_mh.label6_9.caption"
+msgid "Depth of water, m"
+msgstr ""
+
+#: tfreeresistance_mh.label7.caption
+msgctxt "tfreeresistance_mh.label7.caption"
+msgid "Two-screw slender"
+msgstr ""
+
+#: tfreeresistance_mh.label8.caption
+msgctxt "tfreeresistance_mh.label8.caption"
+msgid "Exploitation coefficient"
+msgstr ""
+
+#: tfreeresistance_mh.label9.caption
+msgctxt "tfreeresistance_mh.label9.caption"
+msgid "Number of series ships"
+msgstr ""
+
+#: tfreeresistance_mh.printbutton.caption
+msgctxt "tfreeresistance_mh.printbutton.caption"
+msgid "PrintButton"
+msgstr ""
+
+#: tfreeresistance_mh.printbutton.hint
+msgctxt "tfreeresistance_mh.printbutton.hint"
+msgid "Print the results of the calculation."
+msgstr ""
+
+#: tfreeresistance_mh.results.caption
+msgctxt "tfreeresistance_mh.results.caption"
+msgid "Results"
+msgstr ""
+
+#: tfreeresistance_mh.results2.caption
+msgctxt "tfreeresistance_mh.results2.caption"
+msgid "Help"
+msgstr ""
+
+#: tfreeresistance_mh.toolbar1.caption
+msgctxt "tfreeresistance_mh.toolbar1.caption"
+msgid "ToolBar1"
+msgstr ""
+
+#: tfreeresistance_mh.toolbutton20.hint
+msgctxt "tfreeresistance_mh.toolbutton20.hint"
+msgid "Start the calculation."
+msgstr ""
+
+#: tfreeresistance_mh.toolbutton25.hint
+msgctxt "tfreeresistance_mh.toolbutton25.hint"
+msgid "Close the window and save changes."
+msgstr ""
+
+#: tfreeresistance_mh.toolbutton7.hint
+msgctxt "tfreeresistance_mh.toolbutton7.hint"
+msgid "Close window without saving changes."
+msgstr ""
+
+#: tfreeresistance_mh._label10.caption
+msgctxt "tfreeresistance_mh._label10.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_mh._label11.caption
+msgctxt "tfreeresistance_mh._label11.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_mh._label12.caption
+msgctxt "tfreeresistance_mh._label12.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_mh._label14.caption
+msgctxt "tfreeresistance_mh._label14.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_mh._label15.caption
+msgctxt "tfreeresistance_mh._label15.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_mh._label16.caption
+msgctxt "tfreeresistance_mh._label16.caption"
+msgid "[%]"
+msgstr ""
+
+#: tfreeresistance_mh._label31.caption
+msgctxt "tfreeresistance_mh._label31.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_mh._label32.caption
+msgctxt "tfreeresistance_mh._label32.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_mh._label33.caption
+msgctxt "tfreeresistance_mh._label33.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_mh._label36.caption
+msgctxt "tfreeresistance_mh._label36.caption"
+msgid "E-6  m2/s"
+msgstr ""
+
+#: tfreeresistance_mh._label8.caption
+msgctxt "tfreeresistance_mh._label8.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_mh._label9.caption
+msgctxt "tfreeresistance_mh._label9.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_mh._toolbutton10.caption
+msgctxt "tfreeresistance_mh._toolbutton10.caption"
+msgid "_ToolButton10"
+msgstr ""
+
+#: tfreeresistance_mh._toolbutton14.caption
+msgctxt "tfreeresistance_mh._toolbutton14.caption"
+msgid "_ToolButton14"
+msgstr ""
+
+#: tfreeresistance_oortmer.a11box.text
+msgctxt "tfreeresistance_oortmer.a11box.text"
+msgid "Passenger ship and ferry"
+msgstr ""
+
+#: tfreeresistance_oortmer.caption
+msgid "Resistance for small displacement ships methods"
+msgstr ""
+
+#: tfreeresistance_oortmer.chart.axislist[0].title.caption
+msgctxt "tfreeresistance_oortmer.chart.axislist[0].title.caption"
+msgid "Resistance [kN]"
+msgstr "Resistência [kN]"
+
+#: tfreeresistance_oortmer.chart.axislist[1].title.caption
+msgctxt "tfreeresistance_oortmer.chart.axislist[1].title.caption"
+msgid "Speed [knots]"
+msgstr ""
+
+#: tfreeresistance_oortmer.chart.axislist[2].title.caption
+msgctxt "tfreeresistance_oortmer.chart.axislist[2].title.caption"
+msgid "Power [kW]"
+msgstr ""
+
+#: tfreeresistance_oortmer.checkbox2.caption
+msgctxt "tfreeresistance_oortmer.checkbox2.caption"
+msgid "Extract data from current hull"
+msgstr ""
+
+#: tfreeresistance_oortmer.combobox.text
+msgid "van Oortmerssen 1971"
+msgstr ""
+
+#: tfreeresistance_oortmer.data2.caption
+msgctxt "tfreeresistance_oortmer.data2.caption"
+msgid "Added data"
+msgstr ""
+
+#: tfreeresistance_oortmer.estimate2box.caption
+msgctxt "tfreeresistance_oortmer.estimate2box.caption"
+msgid "Use calculated"
+msgstr ""
+
+#: tfreeresistance_oortmer.estimatebox.caption
+msgctxt "tfreeresistance_oortmer.estimatebox.caption"
+msgid "Use estimate"
+msgstr ""
+
+#: tfreeresistance_oortmer.general.caption
+msgctxt "tfreeresistance_oortmer.general.caption"
+msgid "General"
+msgstr ""
+
+#: tfreeresistance_oortmer.groupbox1.caption
+msgctxt "tfreeresistance_oortmer.groupbox1.caption"
+msgid "General"
+msgstr ""
+
+#: tfreeresistance_oortmer.groupbox2.caption
+msgctxt "tfreeresistance_oortmer.groupbox2.caption"
+msgid "Hull"
+msgstr "Casco"
+
+#: tfreeresistance_oortmer.groupbox3.caption
+msgctxt "tfreeresistance_oortmer.groupbox3.caption"
+msgid "Added data input:"
+msgstr ""
+
+#: tfreeresistance_oortmer.groupbox4.caption
+msgctxt "tfreeresistance_oortmer.groupbox4.caption"
+msgid "Number of appendages :"
+msgstr ""
+
+#: tfreeresistance_oortmer.label1.caption
+msgctxt "tfreeresistance_oortmer.label1.caption"
+msgid "Start speed"
+msgstr ""
+
+#: tfreeresistance_oortmer.label10.caption
+msgctxt "tfreeresistance_oortmer.label10.caption"
+msgid "1/2 entrance angle, degr"
+msgstr ""
+
+#: tfreeresistance_oortmer.label11.caption
+msgctxt "tfreeresistance_oortmer.label11.caption"
+msgid "Full Cargo or Ballast (0...1)"
+msgstr ""
+
+#: tfreeresistance_oortmer.label13.caption
+msgctxt "tfreeresistance_oortmer.label13.caption"
+msgid "Wetted surface"
+msgstr "Superfície molhada"
+
+#: tfreeresistance_oortmer.label14.caption
+msgctxt "tfreeresistance_oortmer.label14.caption"
+msgid "Form stern coefficient"
+msgstr ""
+
+#: tfreeresistance_oortmer.label15.caption
+msgctxt "tfreeresistance_oortmer.label15.caption"
+msgid "Number of propellers"
+msgstr ""
+
+#: tfreeresistance_oortmer.label16.caption
+msgctxt "tfreeresistance_oortmer.label16.caption"
+msgid "Propeller diameter, m"
+msgstr ""
+
+#: tfreeresistance_oortmer.label17.caption
+msgctxt "tfreeresistance_oortmer.label17.caption"
+msgid "Absolute roughness, mkm"
+msgstr ""
+
+#: tfreeresistance_oortmer.label2.caption
+msgctxt "tfreeresistance_oortmer.label2.caption"
+msgid "End speed "
+msgstr ""
+
+#: tfreeresistance_oortmer.label20.caption
+msgctxt "tfreeresistance_oortmer.label20.caption"
+msgid "Midship draft"
+msgstr ""
+
+#: tfreeresistance_oortmer.label21.caption
+msgctxt "tfreeresistance_oortmer.label21.caption"
+msgid "Different"
+msgstr ""
+
+#: tfreeresistance_oortmer.label22.caption
+msgctxt "tfreeresistance_oortmer.label22.caption"
+msgid "Beam waterline "
+msgstr ""
+
+#: tfreeresistance_oortmer.label23.caption
+msgctxt "tfreeresistance_oortmer.label23.caption"
+msgid "Length waterline"
+msgstr ""
+
+#: tfreeresistance_oortmer.label24.caption
+msgctxt "tfreeresistance_oortmer.label24.caption"
+msgid "Prismatic coefficient "
+msgstr ""
+
+#: tfreeresistance_oortmer.label25.caption
+msgctxt "tfreeresistance_oortmer.label25.caption"
+msgid "LCB"
+msgstr ""
+
+#: tfreeresistance_oortmer.label26.caption
+msgctxt "tfreeresistance_oortmer.label26.caption"
+msgid "Displacement"
+msgstr "Deslocamento"
+
+#: tfreeresistance_oortmer.label27.caption
+msgctxt "tfreeresistance_oortmer.label27.caption"
+msgid "Length over surface"
+msgstr ""
+
+#: tfreeresistance_oortmer.label28.caption
+msgctxt "tfreeresistance_oortmer.label28.caption"
+msgid "Skeg"
+msgstr ""
+
+#: tfreeresistance_oortmer.label281.caption
+msgctxt "tfreeresistance_oortmer.label281.caption"
+msgid "Keel and skeg:"
+msgstr ""
+
+#: tfreeresistance_oortmer.label29.caption
+msgctxt "tfreeresistance_oortmer.label29.caption"
+msgid "Bilge keels"
+msgstr ""
+
+#: tfreeresistance_oortmer.label3.caption
+msgctxt "tfreeresistance_oortmer.label3.caption"
+msgid "Step"
+msgstr ""
+
+#: tfreeresistance_oortmer.label30.caption
+msgctxt "tfreeresistance_oortmer.label30.caption"
+msgid "Shaft brackets"
+msgstr ""
+
+#: tfreeresistance_oortmer.label31.caption
+msgctxt "tfreeresistance_oortmer.label31.caption"
+msgid "Strut bossing"
+msgstr ""
+
+#: tfreeresistance_oortmer.label32.caption
+msgctxt "tfreeresistance_oortmer.label32.caption"
+msgid "Hull bossing"
+msgstr ""
+
+#: tfreeresistance_oortmer.label33.caption
+msgctxt "tfreeresistance_oortmer.label33.caption"
+msgid "Exposed shafts:"
+msgstr ""
+
+#: tfreeresistance_oortmer.label34.caption
+msgctxt "tfreeresistance_oortmer.label34.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_oortmer.label35.caption
+msgctxt "tfreeresistance_oortmer.label35.caption"
+msgid "Angle with buttocks about 10"
+msgstr ""
+
+#: tfreeresistance_oortmer.label36.caption
+msgctxt "tfreeresistance_oortmer.label36.caption"
+msgid "Angle with buttocks about 20"
+msgstr ""
+
+#: tfreeresistance_oortmer.label37.caption
+msgctxt "tfreeresistance_oortmer.label37.caption"
+msgid "Stabiliser fins"
+msgstr ""
+
+#: tfreeresistance_oortmer.label38.caption
+msgctxt "tfreeresistance_oortmer.label38.caption"
+msgid "Dome"
+msgstr ""
+
+#: tfreeresistance_oortmer.label4.caption
+msgctxt "tfreeresistance_oortmer.label4.caption"
+msgid "Water density"
+msgstr ""
+
+#: tfreeresistance_oortmer.label48.caption
+msgctxt "tfreeresistance_oortmer.label48.caption"
+msgid "Calculation method:"
+msgstr ""
+
+#: tfreeresistance_oortmer.label5.caption
+msgctxt "tfreeresistance_oortmer.label5.caption"
+msgid "Viscosity"
+msgstr ""
+
+#: tfreeresistance_oortmer.label6.caption
+msgctxt "tfreeresistance_oortmer.label6.caption"
+msgid "Rudder behind skeg/stern"
+msgstr ""
+
+#: tfreeresistance_oortmer.label61.caption
+msgctxt "tfreeresistance_oortmer.label61.caption"
+msgid "Presence of rudders (0-No, 1-Yes):"
+msgstr ""
+
+#: tfreeresistance_oortmer.label6_1.caption
+msgctxt "tfreeresistance_oortmer.label6_1.caption"
+msgid "Time ship hull is in water, month"
+msgstr ""
+
+#: tfreeresistance_oortmer.label6_10.caption
+msgctxt "tfreeresistance_oortmer.label6_10.caption"
+msgid "Wetted area of midship, m^2"
+msgstr ""
+
+#: tfreeresistance_oortmer.label6_11.caption
+msgctxt "tfreeresistance_oortmer.label6_11.caption"
+msgid "Type of ship:"
+msgstr ""
+
+#: tfreeresistance_oortmer.label6_2.caption
+msgctxt "tfreeresistance_oortmer.label6_2.caption"
+msgid "Height of 3% wave, m "
+msgstr ""
+
+#: tfreeresistance_oortmer.label6_3.caption
+msgctxt "tfreeresistance_oortmer.label6_3.caption"
+msgid "Course angle of moving wave, degree"
+msgstr ""
+
+#: tfreeresistance_oortmer.label6_4.caption
+msgctxt "tfreeresistance_oortmer.label6_4.caption"
+msgid "Wind speed, m/s"
+msgstr ""
+
+#: tfreeresistance_oortmer.label6_5.caption
+msgctxt "tfreeresistance_oortmer.label6_5.caption"
+msgid "Course wind angle, degree"
+msgstr ""
+
+#: tfreeresistance_oortmer.label6_6.caption
+msgctxt "tfreeresistance_oortmer.label6_6.caption"
+msgid "Height of board above water, m"
+msgstr ""
+
+#: tfreeresistance_oortmer.label6_7.caption
+msgctxt "tfreeresistance_oortmer.label6_7.caption"
+msgid "Air density, kg/m^3"
+msgstr ""
+
+#: tfreeresistance_oortmer.label6_8.caption
+msgctxt "tfreeresistance_oortmer.label6_8.caption"
+msgid "Height of COG area of superstructure above waterline, m"
+msgstr ""
+
+#: tfreeresistance_oortmer.label6_9.caption
+msgctxt "tfreeresistance_oortmer.label6_9.caption"
+msgid "Depth of water, m"
+msgstr ""
+
+#: tfreeresistance_oortmer.label7.caption
+msgctxt "tfreeresistance_oortmer.label7.caption"
+msgid "Two-screw slender"
+msgstr ""
+
+#: tfreeresistance_oortmer.label8.caption
+msgctxt "tfreeresistance_oortmer.label8.caption"
+msgid "Sea margin coefficient"
+msgstr ""
+
+#: tfreeresistance_oortmer.label9.caption
+msgctxt "tfreeresistance_oortmer.label9.caption"
+msgid "Number of thrusters (0...2)"
+msgstr ""
+
+#: tfreeresistance_oortmer.printbutton.caption
+msgctxt "tfreeresistance_oortmer.printbutton.caption"
+msgid "PrintButton"
+msgstr ""
+
+#: tfreeresistance_oortmer.printbutton.hint
+msgctxt "tfreeresistance_oortmer.printbutton.hint"
+msgid "Print the results of the calculation."
+msgstr ""
+
+#: tfreeresistance_oortmer.results.caption
+msgctxt "tfreeresistance_oortmer.results.caption"
+msgid "Results"
+msgstr ""
+
+#: tfreeresistance_oortmer.results2.caption
+msgctxt "tfreeresistance_oortmer.results2.caption"
+msgid "Help"
+msgstr ""
+
+#: tfreeresistance_oortmer.toolbar1.caption
+msgctxt "tfreeresistance_oortmer.toolbar1.caption"
+msgid "ToolBar1"
+msgstr ""
+
+#: tfreeresistance_oortmer.toolbutton20.hint
+msgctxt "tfreeresistance_oortmer.toolbutton20.hint"
+msgid "Start the calculation."
+msgstr ""
+
+#: tfreeresistance_oortmer.toolbutton25.hint
+msgctxt "tfreeresistance_oortmer.toolbutton25.hint"
+msgid "Close the window and save changes."
+msgstr ""
+
+#: tfreeresistance_oortmer.toolbutton7.hint
+msgctxt "tfreeresistance_oortmer.toolbutton7.hint"
+msgid "Close window without saving changes."
+msgstr ""
+
+#: tfreeresistance_oortmer._label10.caption
+msgctxt "tfreeresistance_oortmer._label10.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_oortmer._label11.caption
+msgctxt "tfreeresistance_oortmer._label11.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_oortmer._label12.caption
+msgctxt "tfreeresistance_oortmer._label12.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_oortmer._label14.caption
+msgctxt "tfreeresistance_oortmer._label14.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_oortmer._label15.caption
+msgctxt "tfreeresistance_oortmer._label15.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_oortmer._label16.caption
+msgctxt "tfreeresistance_oortmer._label16.caption"
+msgid "[%]"
+msgstr ""
+
+#: tfreeresistance_oortmer._label31.caption
+msgctxt "tfreeresistance_oortmer._label31.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_oortmer._label32.caption
+msgctxt "tfreeresistance_oortmer._label32.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_oortmer._label33.caption
+msgctxt "tfreeresistance_oortmer._label33.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_oortmer._label36.caption
+msgctxt "tfreeresistance_oortmer._label36.caption"
+msgid "E-6  m2/s"
+msgstr ""
+
+#: tfreeresistance_oortmer._label8.caption
+msgctxt "tfreeresistance_oortmer._label8.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_oortmer._label9.caption
+msgctxt "tfreeresistance_oortmer._label9.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_oortmer._toolbutton10.caption
+msgctxt "tfreeresistance_oortmer._toolbutton10.caption"
+msgid "_ToolButton10"
+msgstr ""
+
+#: tfreeresistance_oortmer._toolbutton14.caption
+msgctxt "tfreeresistance_oortmer._toolbutton14.caption"
+msgid "_ToolButton14"
+msgstr ""
+
+#: tfreeresistance_ost.a11box.text
+msgctxt "tfreeresistance_ost.a11box.text"
+msgid "Passenger ship and ferry"
+msgstr ""
+
+#: tfreeresistance_ost.caption
+msgctxt "tfreeresistance_ost.caption"
+msgid "Resistance for displacement ships"
+msgstr ""
+
+#: tfreeresistance_ost.chart.axislist[0].title.caption
+msgctxt "tfreeresistance_ost.chart.axislist[0].title.caption"
+msgid "Resistance [kN]"
+msgstr "Resistência [kN]"
+
+#: tfreeresistance_ost.chart.axislist[1].title.caption
+msgctxt "tfreeresistance_ost.chart.axislist[1].title.caption"
+msgid "Speed [knots]"
+msgstr ""
+
+#: tfreeresistance_ost.chart.axislist[2].title.caption
+msgctxt "tfreeresistance_ost.chart.axislist[2].title.caption"
+msgid "Power [kW]"
+msgstr ""
+
+#: tfreeresistance_ost.checkbox2.caption
+msgctxt "tfreeresistance_ost.checkbox2.caption"
+msgid "Extract data from current hull"
+msgstr ""
+
+#: tfreeresistance_ost.combobox.text
+msgctxt "tfreeresistance_ost.combobox.text"
+msgid "Any displacement ships"
+msgstr ""
+
+#: tfreeresistance_ost.data2.caption
+msgctxt "tfreeresistance_ost.data2.caption"
+msgid "Added data"
+msgstr ""
+
+#: tfreeresistance_ost.estimate2box.caption
+msgctxt "tfreeresistance_ost.estimate2box.caption"
+msgid "Use calculated"
+msgstr ""
+
+#: tfreeresistance_ost.estimatebox.caption
+msgctxt "tfreeresistance_ost.estimatebox.caption"
+msgid "Use estimate"
+msgstr ""
+
+#: tfreeresistance_ost.general.caption
+msgctxt "tfreeresistance_ost.general.caption"
+msgid "General"
+msgstr ""
+
+#: tfreeresistance_ost.groupbox1.caption
+msgctxt "tfreeresistance_ost.groupbox1.caption"
+msgid "General"
+msgstr ""
+
+#: tfreeresistance_ost.groupbox2.caption
+msgctxt "tfreeresistance_ost.groupbox2.caption"
+msgid "Hull"
+msgstr "Casco"
+
+#: tfreeresistance_ost.groupbox3.caption
+msgctxt "tfreeresistance_ost.groupbox3.caption"
+msgid "Added data input:"
+msgstr ""
+
+#: tfreeresistance_ost.groupbox4.caption
+msgctxt "tfreeresistance_ost.groupbox4.caption"
+msgid "Number of appendages :"
+msgstr ""
+
+#: tfreeresistance_ost.label1.caption
+msgctxt "tfreeresistance_ost.label1.caption"
+msgid "Start speed"
+msgstr ""
+
+#: tfreeresistance_ost.label10.caption
+msgctxt "tfreeresistance_ost.label10.caption"
+msgid "Type of forward stern"
+msgstr ""
+
+#: tfreeresistance_ost.label11.caption
+msgctxt "tfreeresistance_ost.label11.caption"
+msgid "Type of after stern"
+msgstr ""
+
+#: tfreeresistance_ost.label13.caption
+msgctxt "tfreeresistance_ost.label13.caption"
+msgid "Wetted surface"
+msgstr "Superfície molhada"
+
+#: tfreeresistance_ost.label15.caption
+msgctxt "tfreeresistance_ost.label15.caption"
+msgid "Number of propellers"
+msgstr ""
+
+#: tfreeresistance_ost.label16.caption
+msgctxt "tfreeresistance_ost.label16.caption"
+msgid "Propeller diametr, m"
+msgstr ""
+
+#: tfreeresistance_ost.label17.caption
+msgctxt "tfreeresistance_ost.label17.caption"
+msgid "Absolute roughness, mkm"
+msgstr ""
+
+#: tfreeresistance_ost.label19.caption
+msgctxt "tfreeresistance_ost.label19.caption"
+msgid "Type of ships:"
+msgstr ""
+
+#: tfreeresistance_ost.label2.caption
+msgctxt "tfreeresistance_ost.label2.caption"
+msgid "End speed "
+msgstr ""
+
+#: tfreeresistance_ost.label20.caption
+msgctxt "tfreeresistance_ost.label20.caption"
+msgid "Midship draft"
+msgstr ""
+
+#: tfreeresistance_ost.label21.caption
+msgctxt "tfreeresistance_ost.label21.caption"
+msgid "Different"
+msgstr ""
+
+#: tfreeresistance_ost.label22.caption
+msgctxt "tfreeresistance_ost.label22.caption"
+msgid "Beam waterline "
+msgstr ""
+
+#: tfreeresistance_ost.label23.caption
+msgctxt "tfreeresistance_ost.label23.caption"
+msgid "Length waterline"
+msgstr ""
+
+#: tfreeresistance_ost.label24.caption
+msgctxt "tfreeresistance_ost.label24.caption"
+msgid "Prismatic coefficient "
+msgstr ""
+
+#: tfreeresistance_ost.label25.caption
+msgctxt "tfreeresistance_ost.label25.caption"
+msgid "LCB"
+msgstr ""
+
+#: tfreeresistance_ost.label26.caption
+msgctxt "tfreeresistance_ost.label26.caption"
+msgid "Displacement"
+msgstr "Deslocamento"
+
+#: tfreeresistance_ost.label27.caption
+msgctxt "tfreeresistance_ost.label27.caption"
+msgid "Waterplane area"
+msgstr ""
+
+#: tfreeresistance_ost.label281.caption
+msgctxt "tfreeresistance_ost.label281.caption"
+msgid "Keel and skeg:"
+msgstr ""
+
+#: tfreeresistance_ost.label3.caption
+msgctxt "tfreeresistance_ost.label3.caption"
+msgid "Step"
+msgstr ""
+
+#: tfreeresistance_ost.label30.caption
+msgctxt "tfreeresistance_ost.label30.caption"
+msgid "Shaft brackets"
+msgstr ""
+
+#: tfreeresistance_ost.label31.caption
+msgctxt "tfreeresistance_ost.label31.caption"
+msgid "Strut bossing"
+msgstr ""
+
+#: tfreeresistance_ost.label32.caption
+msgctxt "tfreeresistance_ost.label32.caption"
+msgid "Hull bossing"
+msgstr ""
+
+#: tfreeresistance_ost.label33.caption
+msgctxt "tfreeresistance_ost.label33.caption"
+msgid "Exposed shafts:"
+msgstr ""
+
+#: tfreeresistance_ost.label34.caption
+msgctxt "tfreeresistance_ost.label34.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_ost.label35.caption
+msgctxt "tfreeresistance_ost.label35.caption"
+msgid "Angle with buttocks about 10"
+msgstr ""
+
+#: tfreeresistance_ost.label36.caption
+msgctxt "tfreeresistance_ost.label36.caption"
+msgid "Angle with buttocks about 20"
+msgstr ""
+
+#: tfreeresistance_ost.label37.caption
+msgctxt "tfreeresistance_ost.label37.caption"
+msgid "Stabiliser fins"
+msgstr ""
+
+#: tfreeresistance_ost.label38.caption
+msgctxt "tfreeresistance_ost.label38.caption"
+msgid "Dome"
+msgstr ""
+
+#: tfreeresistance_ost.label39.caption
+msgctxt "tfreeresistance_ost.label39.caption"
+msgid "Skeg"
+msgstr ""
+
+#: tfreeresistance_ost.label4.caption
+msgctxt "tfreeresistance_ost.label4.caption"
+msgid "Water density"
+msgstr ""
+
+#: tfreeresistance_ost.label40.caption
+msgctxt "tfreeresistance_ost.label40.caption"
+msgid "Bilge keels"
+msgstr ""
+
+#: tfreeresistance_ost.label5.caption
+msgctxt "tfreeresistance_ost.label5.caption"
+msgid "Viscosity"
+msgstr ""
+
+#: tfreeresistance_ost.label6.caption
+msgctxt "tfreeresistance_ost.label6.caption"
+msgid "Rudder behind skeg/stern"
+msgstr ""
+
+#: tfreeresistance_ost.label61.caption
+msgctxt "tfreeresistance_ost.label61.caption"
+msgid "Presence of rudders (0-No, 1-Yes):"
+msgstr ""
+
+#: tfreeresistance_ost.label6_1.caption
+msgctxt "tfreeresistance_ost.label6_1.caption"
+msgid "Time ship hull is in water, month"
+msgstr ""
+
+#: tfreeresistance_ost.label6_10.caption
+msgctxt "tfreeresistance_ost.label6_10.caption"
+msgid "Wetted area of midship, m^2"
+msgstr ""
+
+#: tfreeresistance_ost.label6_11.caption
+msgctxt "tfreeresistance_ost.label6_11.caption"
+msgid "Type of ship:"
+msgstr ""
+
+#: tfreeresistance_ost.label6_2.caption
+msgctxt "tfreeresistance_ost.label6_2.caption"
+msgid "Height of 3% wave, m "
+msgstr ""
+
+#: tfreeresistance_ost.label6_3.caption
+msgctxt "tfreeresistance_ost.label6_3.caption"
+msgid "Course angle of moving wave, degree"
+msgstr ""
+
+#: tfreeresistance_ost.label6_4.caption
+msgctxt "tfreeresistance_ost.label6_4.caption"
+msgid "Wind speed, m/s"
+msgstr ""
+
+#: tfreeresistance_ost.label6_5.caption
+msgctxt "tfreeresistance_ost.label6_5.caption"
+msgid "Course wind angle, degree"
+msgstr ""
+
+#: tfreeresistance_ost.label6_6.caption
+msgctxt "tfreeresistance_ost.label6_6.caption"
+msgid "Height of board above water, m"
+msgstr ""
+
+#: tfreeresistance_ost.label6_7.caption
+msgctxt "tfreeresistance_ost.label6_7.caption"
+msgid "Air density, kg/m^3"
+msgstr ""
+
+#: tfreeresistance_ost.label6_8.caption
+msgctxt "tfreeresistance_ost.label6_8.caption"
+msgid "Height of COG area of superstructure above waterline, m"
+msgstr ""
+
+#: tfreeresistance_ost.label6_9.caption
+msgctxt "tfreeresistance_ost.label6_9.caption"
+msgid "Depth of water, m"
+msgstr ""
+
+#: tfreeresistance_ost.label7.caption
+msgctxt "tfreeresistance_ost.label7.caption"
+msgid "Two-screw slender"
+msgstr ""
+
+#: tfreeresistance_ost.label8.caption
+msgctxt "tfreeresistance_ost.label8.caption"
+msgid "Exploitation coefficient"
+msgstr ""
+
+#: tfreeresistance_ost.label9.caption
+msgctxt "tfreeresistance_ost.label9.caption"
+msgid "Number of series ships"
+msgstr ""
+
+#: tfreeresistance_ost.printbutton.caption
+msgctxt "tfreeresistance_ost.printbutton.caption"
+msgid "PrintButton"
+msgstr ""
+
+#: tfreeresistance_ost.printbutton.hint
+msgctxt "tfreeresistance_ost.printbutton.hint"
+msgid "Print the results of the calculation."
+msgstr ""
+
+#: tfreeresistance_ost.results.caption
+msgctxt "tfreeresistance_ost.results.caption"
+msgid "Results"
+msgstr ""
+
+#: tfreeresistance_ost.results2.caption
+msgctxt "tfreeresistance_ost.results2.caption"
+msgid "Help"
+msgstr ""
+
+#: tfreeresistance_ost.toolbar1.caption
+msgctxt "tfreeresistance_ost.toolbar1.caption"
+msgid "ToolBar1"
+msgstr ""
+
+#: tfreeresistance_ost.toolbutton20.hint
+msgctxt "tfreeresistance_ost.toolbutton20.hint"
+msgid "Start the calculation."
+msgstr ""
+
+#: tfreeresistance_ost.toolbutton25.hint
+msgctxt "tfreeresistance_ost.toolbutton25.hint"
+msgid "Close the window and save changes."
+msgstr ""
+
+#: tfreeresistance_ost.toolbutton7.hint
+msgctxt "tfreeresistance_ost.toolbutton7.hint"
+msgid "Close window without saving changes."
+msgstr ""
+
+#: tfreeresistance_ost._label10.caption
+msgctxt "tfreeresistance_ost._label10.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_ost._label11.caption
+msgctxt "tfreeresistance_ost._label11.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_ost._label12.caption
+msgctxt "tfreeresistance_ost._label12.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_ost._label14.caption
+msgctxt "tfreeresistance_ost._label14.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_ost._label15.caption
+msgctxt "tfreeresistance_ost._label15.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_ost._label16.caption
+msgctxt "tfreeresistance_ost._label16.caption"
+msgid "[%]"
+msgstr ""
+
+#: tfreeresistance_ost._label31.caption
+msgctxt "tfreeresistance_ost._label31.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_ost._label32.caption
+msgctxt "tfreeresistance_ost._label32.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_ost._label33.caption
+msgctxt "tfreeresistance_ost._label33.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_ost._label36.caption
+msgctxt "tfreeresistance_ost._label36.caption"
+msgid "*10-6  m2/s"
+msgstr ""
+
+#: tfreeresistance_ost._label8.caption
+msgctxt "tfreeresistance_ost._label8.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_ost._label9.caption
+msgctxt "tfreeresistance_ost._label9.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_ost._toolbutton10.caption
+msgctxt "tfreeresistance_ost._toolbutton10.caption"
+msgid "_ToolButton10"
+msgstr ""
+
+#: tfreeresistance_ost._toolbutton14.caption
+msgctxt "tfreeresistance_ost._toolbutton14.caption"
+msgid "_ToolButton14"
+msgstr ""
+
+#: tfreeresistance_planing.caption
+msgid "Planing resistance calculation."
+msgstr ""
+
+#: tfreeresistance_planing.checkbox2.caption
+msgctxt "tfreeresistance_planing.checkbox2.caption"
+msgid "Extract data from current hull"
+msgstr ""
+
+#: tfreeresistance_planing.checkbox3.caption
+msgid "Add aerodynamic resistance"
+msgstr ""
+
+#: tfreeresistance_planing.checkbox4.caption
+msgid "Add appendage resistance with steady engine"
+msgstr ""
+
+#: tfreeresistance_planing.checkbox5.caption
+msgid "Add spray strip influence"
+msgstr ""
+
+#: tfreeresistance_planing.checkbox6.caption
+msgid "Add round bilge influence"
+msgstr ""
+
+#: tfreeresistance_planing.combobox.text
+msgid "Sedov-Perelmootre"
+msgstr ""
+
+#: tfreeresistance_planing.combobox1.text
+msgid "Waterjet"
+msgstr ""
+
+#: tfreeresistance_planing.edit6.hint
+msgid "0.40 .. 0.90"
+msgstr ""
+
+#: tfreeresistance_planing.label10.caption
+msgctxt "tfreeresistance_planing.label10.caption"
+msgid "[-]"
+msgstr ""
+
+#: tfreeresistance_planing.label11.caption
+msgctxt "tfreeresistance_planing.label11.caption"
+msgid "[-]"
+msgstr ""
+
+#: tfreeresistance_planing.label13.caption
+msgctxt "tfreeresistance_planing.label13.caption"
+msgid "Displacement"
+msgstr "Deslocamento"
+
+#: tfreeresistance_planing.label14.caption
+msgctxt "tfreeresistance_planing.label14.caption"
+msgid "[-]"
+msgstr ""
+
+#: tfreeresistance_planing.label15.caption
+msgid "Deadrise @ Amidships"
+msgstr ""
+
+#: tfreeresistance_planing.label16.caption
+msgctxt "tfreeresistance_planing.label16.caption"
+msgid "[-]"
+msgstr ""
+
+#: tfreeresistance_planing.label17.caption
+msgctxt "tfreeresistance_planing.label17.caption"
+msgid "LCB"
+msgstr ""
+
+#: tfreeresistance_planing.label17_.caption
+msgctxt "tfreeresistance_planing.label17_.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_planing.label18.caption
+msgctxt "tfreeresistance_planing.label18.caption"
+msgid "[-]"
+msgstr ""
+
+#: tfreeresistance_planing.label19.caption
+msgid "Amidship area under water"
+msgstr ""
+
+#: tfreeresistance_planing.label19_.caption
+msgctxt "tfreeresistance_planing.label19_.caption"
+msgid "[m2]"
+msgstr ""
+
+#: tfreeresistance_planing.label2.caption
+msgctxt "tfreeresistance_planing.label2.caption"
+msgid "Length waterline"
+msgstr ""
+
+#: tfreeresistance_planing.label20.caption
+msgid "Roughness allowance*10^3"
+msgstr ""
+
+#: tfreeresistance_planing.label21.caption
+msgid "Max. speed"
+msgstr ""
+
+#: tfreeresistance_planing.label21_.caption
+msgid "[kn]"
+msgstr ""
+
+#: tfreeresistance_planing.label22.caption
+msgctxt "tfreeresistance_planing.label22.caption"
+msgid "Calculation method:"
+msgstr ""
+
+#: tfreeresistance_planing.label23.caption
+msgctxt "tfreeresistance_planing.label23.caption"
+msgid "Angle between Thrust and Keel lines"
+msgstr "Ângulo entre as linhas de Empuxo e Quilha"
+
+#: tfreeresistance_planing.label23_.caption
+msgctxt "tfreeresistance_planing.label23_.caption"
+msgid "[degr]"
+msgstr ""
+
+#: tfreeresistance_planing.label24.caption
+msgid "Distance between Thrust line and CG"
+msgstr ""
+
+#: tfreeresistance_planing.label24_.caption
+msgctxt "tfreeresistance_planing.label24_.caption"
+msgid "[ft]"
+msgstr ""
+
+#: tfreeresistance_planing.label25.caption
+msgid "Diameter of propeller"
+msgstr ""
+
+#: tfreeresistance_planing.label25_.caption
+msgctxt "tfreeresistance_planing.label25_.caption"
+msgid "[ft]"
+msgstr ""
+
+#: tfreeresistance_planing.label26.caption
+msgid "Deadrise transom"
+msgstr ""
+
+#: tfreeresistance_planing.label26_.caption
+msgctxt "tfreeresistance_planing.label26_.caption"
+msgid "[degr]"
+msgstr ""
+
+#: tfreeresistance_planing.label27.caption
+msgid "Deadrise redan"
+msgstr ""
+
+#: tfreeresistance_planing.label27_.caption
+msgctxt "tfreeresistance_planing.label27_.caption"
+msgid "[degr]"
+msgstr ""
+
+#: tfreeresistance_planing.label28.caption
+msgid "Propulsor type:"
+msgstr ""
+
+#: tfreeresistance_planing.label3.caption
+msgctxt "tfreeresistance_planing.label3.caption"
+msgid "Beam waterline"
+msgstr ""
+
+#: tfreeresistance_planing.label4.caption
+msgctxt "tfreeresistance_planing.label4.caption"
+msgid "Draft"
+msgstr ""
+
+#: tfreeresistance_planing.label6.caption
+msgctxt "tfreeresistance_planing.label6.caption"
+msgid "Wetted surface area"
+msgstr "Área de superfície molhada"
+
+#: tfreeresistance_planing.label7.caption
+msgctxt "tfreeresistance_planing.label7.caption"
+msgid "[-]"
+msgstr ""
+
+#: tfreeresistance_planing.label8.caption
+msgctxt "tfreeresistance_planing.label8.caption"
+msgid "Cp"
+msgstr ""
+
+#: tfreeresistance_planing.label9.caption
+msgctxt "tfreeresistance_planing.label9.caption"
+msgid "[-]"
+msgstr ""
+
+#: tfreeresistance_planing.printbutton.caption
+msgctxt "tfreeresistance_planing.printbutton.caption"
+msgid "PrintButton"
+msgstr ""
+
+#: tfreeresistance_planing.printbutton.hint
+msgctxt "tfreeresistance_planing.printbutton.hint"
+msgid "Print the results of the calculation."
+msgstr ""
+
+#: tfreeresistance_planing.tabsheet1.caption
+msgctxt "tfreeresistance_planing.tabsheet1.caption"
+msgid "General"
+msgstr ""
+
+#: tfreeresistance_planing.tabsheet2.caption
+msgctxt "tfreeresistance_planing.tabsheet2.caption"
+msgid "Results"
+msgstr ""
+
+#: tfreeresistance_planing.toolbar1.caption
+msgctxt "tfreeresistance_planing.toolbar1.caption"
+msgid "ToolBar1"
+msgstr ""
+
+#: tfreeresistance_planing.toolbutton25.hint
+msgctxt "tfreeresistance_planing.toolbutton25.hint"
+msgid "Close the window and save changes."
+msgstr ""
+
+#: tfreeresistance_planing.toolbutton7.hint
+msgctxt "tfreeresistance_planing.toolbutton7.hint"
+msgid "Close window without saving changes."
+msgstr ""
+
+#: tfreeresistance_planing._toolbutton10.caption
+msgctxt "tfreeresistance_planing._toolbutton10.caption"
+msgid "_ToolButton10"
+msgstr ""
+
+#: tfreeresistance_planing._toolbutton14.caption
+msgctxt "tfreeresistance_planing._toolbutton14.caption"
+msgid "_ToolButton14"
+msgstr ""
+
+#: tfreeresistance_rbhs.a11box.text
+msgctxt "tfreeresistance_rbhs.a11box.text"
+msgid "Passenger ship and ferry"
+msgstr ""
+
+#: tfreeresistance_rbhs.caption
+msgctxt "tfreeresistance_rbhs.caption"
+msgid "Resistance for displacement ships"
+msgstr ""
+
+#: tfreeresistance_rbhs.chart.axislist[0].title.caption
+msgctxt "tfreeresistance_rbhs.chart.axislist[0].title.caption"
+msgid "Resistance [kN]"
+msgstr "Resistência [kN]"
+
+#: tfreeresistance_rbhs.chart.axislist[1].title.caption
+msgctxt "tfreeresistance_rbhs.chart.axislist[1].title.caption"
+msgid "Speed [knots]"
+msgstr ""
+
+#: tfreeresistance_rbhs.chart.axislist[2].title.caption
+msgctxt "tfreeresistance_rbhs.chart.axislist[2].title.caption"
+msgid "Power [kW]"
+msgstr ""
+
+#: tfreeresistance_rbhs.checkbox2.caption
+msgctxt "tfreeresistance_rbhs.checkbox2.caption"
+msgid "Extract data from current hull"
+msgstr ""
+
+#: tfreeresistance_rbhs.combobox.text
+msgctxt "tfreeresistance_rbhs.combobox.text"
+msgid "Any displacement ships"
+msgstr ""
+
+#: tfreeresistance_rbhs.data2.caption
+msgctxt "tfreeresistance_rbhs.data2.caption"
+msgid "Added data"
+msgstr ""
+
+#: tfreeresistance_rbhs.estimate2box.caption
+msgctxt "tfreeresistance_rbhs.estimate2box.caption"
+msgid "Use calculated"
+msgstr ""
+
+#: tfreeresistance_rbhs.estimatebox.caption
+msgctxt "tfreeresistance_rbhs.estimatebox.caption"
+msgid "Use estimate"
+msgstr ""
+
+#: tfreeresistance_rbhs.general.caption
+msgctxt "tfreeresistance_rbhs.general.caption"
+msgid "General"
+msgstr ""
+
+#: tfreeresistance_rbhs.groupbox1.caption
+msgctxt "tfreeresistance_rbhs.groupbox1.caption"
+msgid "General"
+msgstr ""
+
+#: tfreeresistance_rbhs.groupbox2.caption
+msgctxt "tfreeresistance_rbhs.groupbox2.caption"
+msgid "Hull"
+msgstr "Casco"
+
+#: tfreeresistance_rbhs.groupbox3.caption
+msgctxt "tfreeresistance_rbhs.groupbox3.caption"
+msgid "Added data input:"
+msgstr ""
+
+#: tfreeresistance_rbhs.groupbox4.caption
+msgctxt "tfreeresistance_rbhs.groupbox4.caption"
+msgid "Number of appendages :"
+msgstr ""
+
+#: tfreeresistance_rbhs.label1.caption
+msgctxt "tfreeresistance_rbhs.label1.caption"
+msgid "Start speed"
+msgstr ""
+
+#: tfreeresistance_rbhs.label10.caption
+msgctxt "tfreeresistance_rbhs.label10.caption"
+msgid "Type of forward stern"
+msgstr ""
+
+#: tfreeresistance_rbhs.label11.caption
+msgctxt "tfreeresistance_rbhs.label11.caption"
+msgid "Type of after stern"
+msgstr ""
+
+#: tfreeresistance_rbhs.label13.caption
+msgctxt "tfreeresistance_rbhs.label13.caption"
+msgid "Wetted surface"
+msgstr "Superfície molhada"
+
+#: tfreeresistance_rbhs.label15.caption
+msgctxt "tfreeresistance_rbhs.label15.caption"
+msgid "Number of propellers"
+msgstr ""
+
+#: tfreeresistance_rbhs.label16.caption
+msgctxt "tfreeresistance_rbhs.label16.caption"
+msgid "Propeller diametr, m"
+msgstr ""
+
+#: tfreeresistance_rbhs.label17.caption
+msgctxt "tfreeresistance_rbhs.label17.caption"
+msgid "Absolute roughness, mkm"
+msgstr ""
+
+#: tfreeresistance_rbhs.label19.caption
+msgctxt "tfreeresistance_rbhs.label19.caption"
+msgid "Type of ships:"
+msgstr ""
+
+#: tfreeresistance_rbhs.label2.caption
+msgctxt "tfreeresistance_rbhs.label2.caption"
+msgid "End speed "
+msgstr ""
+
+#: tfreeresistance_rbhs.label20.caption
+msgctxt "tfreeresistance_rbhs.label20.caption"
+msgid "Midship draft"
+msgstr ""
+
+#: tfreeresistance_rbhs.label21.caption
+msgctxt "tfreeresistance_rbhs.label21.caption"
+msgid "Different"
+msgstr ""
+
+#: tfreeresistance_rbhs.label22.caption
+msgctxt "tfreeresistance_rbhs.label22.caption"
+msgid "Beam waterline "
+msgstr ""
+
+#: tfreeresistance_rbhs.label23.caption
+msgctxt "tfreeresistance_rbhs.label23.caption"
+msgid "Length waterline"
+msgstr ""
+
+#: tfreeresistance_rbhs.label24.caption
+msgctxt "tfreeresistance_rbhs.label24.caption"
+msgid "Prismatic coefficient "
+msgstr ""
+
+#: tfreeresistance_rbhs.label25.caption
+msgctxt "tfreeresistance_rbhs.label25.caption"
+msgid "LCB"
+msgstr ""
+
+#: tfreeresistance_rbhs.label26.caption
+msgctxt "tfreeresistance_rbhs.label26.caption"
+msgid "Displacement"
+msgstr "Deslocamento"
+
+#: tfreeresistance_rbhs.label27.caption
+msgctxt "tfreeresistance_rbhs.label27.caption"
+msgid "Waterplane area"
+msgstr ""
+
+#: tfreeresistance_rbhs.label281.caption
+msgctxt "tfreeresistance_rbhs.label281.caption"
+msgid "Keel and skeg:"
+msgstr ""
+
+#: tfreeresistance_rbhs.label3.caption
+msgctxt "tfreeresistance_rbhs.label3.caption"
+msgid "Step"
+msgstr ""
+
+#: tfreeresistance_rbhs.label30.caption
+msgctxt "tfreeresistance_rbhs.label30.caption"
+msgid "Shaft brackets"
+msgstr ""
+
+#: tfreeresistance_rbhs.label31.caption
+msgctxt "tfreeresistance_rbhs.label31.caption"
+msgid "Strut bossing"
+msgstr ""
+
+#: tfreeresistance_rbhs.label32.caption
+msgctxt "tfreeresistance_rbhs.label32.caption"
+msgid "Hull bossing"
+msgstr ""
+
+#: tfreeresistance_rbhs.label33.caption
+msgctxt "tfreeresistance_rbhs.label33.caption"
+msgid "Exposed shafts:"
+msgstr ""
+
+#: tfreeresistance_rbhs.label34.caption
+msgctxt "tfreeresistance_rbhs.label34.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_rbhs.label35.caption
+msgctxt "tfreeresistance_rbhs.label35.caption"
+msgid "Angle with buttocks about 10"
+msgstr ""
+
+#: tfreeresistance_rbhs.label36.caption
+msgctxt "tfreeresistance_rbhs.label36.caption"
+msgid "Angle with buttocks about 20"
+msgstr ""
+
+#: tfreeresistance_rbhs.label37.caption
+msgctxt "tfreeresistance_rbhs.label37.caption"
+msgid "Stabiliser fins"
+msgstr ""
+
+#: tfreeresistance_rbhs.label38.caption
+msgctxt "tfreeresistance_rbhs.label38.caption"
+msgid "Dome"
+msgstr ""
+
+#: tfreeresistance_rbhs.label39.caption
+msgctxt "tfreeresistance_rbhs.label39.caption"
+msgid "Skeg"
+msgstr ""
+
+#: tfreeresistance_rbhs.label4.caption
+msgctxt "tfreeresistance_rbhs.label4.caption"
+msgid "Water density"
+msgstr ""
+
+#: tfreeresistance_rbhs.label40.caption
+msgctxt "tfreeresistance_rbhs.label40.caption"
+msgid "Bilge keels"
+msgstr ""
+
+#: tfreeresistance_rbhs.label5.caption
+msgctxt "tfreeresistance_rbhs.label5.caption"
+msgid "Viscosity"
+msgstr ""
+
+#: tfreeresistance_rbhs.label6.caption
+msgctxt "tfreeresistance_rbhs.label6.caption"
+msgid "Rudder behind skeg/stern"
+msgstr ""
+
+#: tfreeresistance_rbhs.label61.caption
+msgctxt "tfreeresistance_rbhs.label61.caption"
+msgid "Presence of rudders (0-No, 1-Yes):"
+msgstr ""
+
+#: tfreeresistance_rbhs.label6_1.caption
+msgctxt "tfreeresistance_rbhs.label6_1.caption"
+msgid "Time ship hull is in water, month"
+msgstr ""
+
+#: tfreeresistance_rbhs.label6_10.caption
+msgctxt "tfreeresistance_rbhs.label6_10.caption"
+msgid "Wetted area of midship, m^2"
+msgstr ""
+
+#: tfreeresistance_rbhs.label6_11.caption
+msgctxt "tfreeresistance_rbhs.label6_11.caption"
+msgid "Type of ship:"
+msgstr ""
+
+#: tfreeresistance_rbhs.label6_2.caption
+msgctxt "tfreeresistance_rbhs.label6_2.caption"
+msgid "Height of 3% wave, m "
+msgstr ""
+
+#: tfreeresistance_rbhs.label6_3.caption
+msgctxt "tfreeresistance_rbhs.label6_3.caption"
+msgid "Course angle of moving wave, degree"
+msgstr ""
+
+#: tfreeresistance_rbhs.label6_4.caption
+msgctxt "tfreeresistance_rbhs.label6_4.caption"
+msgid "Wind speed, m/s"
+msgstr ""
+
+#: tfreeresistance_rbhs.label6_5.caption
+msgctxt "tfreeresistance_rbhs.label6_5.caption"
+msgid "Course wind angle, degree"
+msgstr ""
+
+#: tfreeresistance_rbhs.label6_6.caption
+msgctxt "tfreeresistance_rbhs.label6_6.caption"
+msgid "Height of board above water, m"
+msgstr ""
+
+#: tfreeresistance_rbhs.label6_7.caption
+msgctxt "tfreeresistance_rbhs.label6_7.caption"
+msgid "Air density, kg/m^3"
+msgstr ""
+
+#: tfreeresistance_rbhs.label6_8.caption
+msgctxt "tfreeresistance_rbhs.label6_8.caption"
+msgid "Height of COG area of superstructure above waterline, m"
+msgstr ""
+
+#: tfreeresistance_rbhs.label6_9.caption
+msgctxt "tfreeresistance_rbhs.label6_9.caption"
+msgid "Depth of water, m"
+msgstr ""
+
+#: tfreeresistance_rbhs.label7.caption
+msgctxt "tfreeresistance_rbhs.label7.caption"
+msgid "Two-screw slender"
+msgstr ""
+
+#: tfreeresistance_rbhs.label8.caption
+msgctxt "tfreeresistance_rbhs.label8.caption"
+msgid "Exploitation coefficient"
+msgstr ""
+
+#: tfreeresistance_rbhs.label9.caption
+msgctxt "tfreeresistance_rbhs.label9.caption"
+msgid "Number of series ships"
+msgstr ""
+
+#: tfreeresistance_rbhs.printbutton.caption
+msgctxt "tfreeresistance_rbhs.printbutton.caption"
+msgid "PrintButton"
+msgstr ""
+
+#: tfreeresistance_rbhs.printbutton.hint
+msgctxt "tfreeresistance_rbhs.printbutton.hint"
+msgid "Print the results of the calculation."
+msgstr ""
+
+#: tfreeresistance_rbhs.results.caption
+msgctxt "tfreeresistance_rbhs.results.caption"
+msgid "Results"
+msgstr ""
+
+#: tfreeresistance_rbhs.results2.caption
+msgctxt "tfreeresistance_rbhs.results2.caption"
+msgid "Help"
+msgstr ""
+
+#: tfreeresistance_rbhs.toolbar1.caption
+msgctxt "tfreeresistance_rbhs.toolbar1.caption"
+msgid "ToolBar1"
+msgstr ""
+
+#: tfreeresistance_rbhs.toolbutton20.hint
+msgctxt "tfreeresistance_rbhs.toolbutton20.hint"
+msgid "Start the calculation."
+msgstr ""
+
+#: tfreeresistance_rbhs.toolbutton25.hint
+msgctxt "tfreeresistance_rbhs.toolbutton25.hint"
+msgid "Close the window and save changes."
+msgstr ""
+
+#: tfreeresistance_rbhs.toolbutton7.hint
+msgctxt "tfreeresistance_rbhs.toolbutton7.hint"
+msgid "Close window without saving changes."
+msgstr ""
+
+#: tfreeresistance_rbhs._label10.caption
+msgctxt "tfreeresistance_rbhs._label10.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_rbhs._label11.caption
+msgctxt "tfreeresistance_rbhs._label11.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_rbhs._label12.caption
+msgctxt "tfreeresistance_rbhs._label12.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_rbhs._label14.caption
+msgctxt "tfreeresistance_rbhs._label14.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_rbhs._label15.caption
+msgctxt "tfreeresistance_rbhs._label15.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_rbhs._label16.caption
+msgctxt "tfreeresistance_rbhs._label16.caption"
+msgid "[%]"
+msgstr ""
+
+#: tfreeresistance_rbhs._label31.caption
+msgctxt "tfreeresistance_rbhs._label31.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_rbhs._label32.caption
+msgctxt "tfreeresistance_rbhs._label32.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_rbhs._label33.caption
+msgctxt "tfreeresistance_rbhs._label33.caption"
+msgid "kn"
+msgstr ""
+
+#: tfreeresistance_rbhs._label36.caption
+msgctxt "tfreeresistance_rbhs._label36.caption"
+msgid "*10-6  m2/s"
+msgstr ""
+
+#: tfreeresistance_rbhs._label8.caption
+msgctxt "tfreeresistance_rbhs._label8.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_rbhs._label9.caption
+msgctxt "tfreeresistance_rbhs._label9.caption"
+msgid "[m]"
+msgstr ""
+
+#: tfreeresistance_rbhs._toolbutton10.caption
+msgctxt "tfreeresistance_rbhs._toolbutton10.caption"
+msgid "_ToolButton10"
+msgstr ""
+
+#: tfreeresistance_rbhs._toolbutton14.caption
+msgctxt "tfreeresistance_rbhs._toolbutton14.caption"
+msgid "_ToolButton14"
+msgstr ""
+
+#: tfreesplashwindow.button1.caption
+msgid "Read GPL"
+msgstr ""
+
+#: tfreesplashwindow.button2.caption
+msgctxt "tfreesplashwindow.button2.caption"
+msgid "Close"
+msgstr ""
+
+#: tfreesplashwindow.caption
+msgctxt "tfreesplashwindow.caption"
+msgid "FREE!ship Plus"
+msgstr ""
+
+#: tfreesplashwindow.checkbox1.caption
+msgid "I accept"
+msgstr ""
+
+#: tfreesplashwindow.checkbox1.hint
+msgid "I accept License terms and conditions"
+msgstr ""
+
+#: tfreesplashwindow.label2.caption
+msgid "Copyright © 2007-2013,Timoshenko V.F."
+msgstr ""
+
+#: tfreesplashwindow.label3.caption
+msgid "Copyright © 2015+, Mark Malakanov"
+msgstr ""
+
+#: tfreesplashwindow.label4.caption
+msgid "Please accept License terms and conditions"
+msgstr ""
+
+#: tfreesplashwindow.labelappname.caption
+msgctxt "tfreesplashwindow.labelappname.caption"
+msgid "FREE!ship Plus"
+msgstr ""
+
+#: tfreesplashwindow.labelbuildinfo.caption
+msgctxt "tfreesplashwindow.labelbuildinfo.caption"
+msgid "Build"
+msgstr ""
+
+#: tfreesplashwindow.labelcondition.caption
+msgid ""
+"This is free software, and you are welcome to redistribute it under the "
+"conditions of the GNU General Public License (GPL) Version 3,  29 June 2007 "
+"or later"
+msgstr ""
+
+#: tfreesplashwindow.labelrelease.caption
+msgctxt "tfreesplashwindow.labelrelease.caption"
+msgid "Release"
+msgstr ""
+
+#: tfreesplashwindow.labelversion.caption
+msgid "Version 0.00"
+msgstr ""
+
+#: tfreesplashwindow.labelwarranty.caption
+msgid ""
+"THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR "
+"IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, "
+"FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE "
+"AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER "
+"LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING "
+"FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS "
+"IN THE SOFTWARE."
+msgstr ""
+
+#: tfreesplashwindow._label2.caption
+msgid "Copyright © 2005-2006, M v. Engeland"
+msgstr ""
+
+#: tfreesplashwindow._label8.caption
+msgid "Translated by: M. van Engeland"
+msgstr ""
+
+#: tfreeupdateform.actioncheckupdate.caption
+msgctxt "tfreeupdateform.actioncheckupdate.caption"
+msgid "Check Update"
+msgstr ""
+
+#: tfreeupdateform.bitbtn2.caption
+msgctxt "tfreeupdateform.bitbtn2.caption"
+msgid "Close"
+msgstr ""
+
+#: tfreeupdateform.caption
+msgid "Check updates"
+msgstr ""
+
+#: tfreeupdateform.label1.caption
+msgid "Current Version:"
+msgstr ""
+
+#: tfreeupdateform.label3.caption
+msgctxt "tfreeupdateform.label3.caption"
+msgid "What's new"
+msgstr ""
+
+#: tfreeupdateform.label4.caption
+msgid "Download link:"
+msgstr ""
+
+#: tfreeupdateform.label6.caption
+msgid "Download page:"
+msgstr ""
+
+#: tfreeupdateform.labelcurrentversion.caption
+msgid "1.2.3.4"
+msgstr ""
+
+#: tfreeupdateform.labeldownloadlink.caption
+msgid "LabelDownloadLink"
+msgstr ""
+
+#: tfreeupdateform.labeldownloadpage.caption
+msgid "LabelDownloadPage"
+msgstr ""
+
+#: tfreeupdateform.labelnewversion.caption
+msgid "LabelNewVersion"
+msgstr ""
+
+#: tfreeupdateform.labelnewversionavailable.caption
+msgid "New version available:"
+msgstr ""
+
+#: tfreeupdateform.labelnewversiondate.caption
+msgid "LabelNewVersionDate"
+msgstr ""
+
+#: tfreeupdateform.speedbutton1.hint
+msgid "Refresh"
+msgstr ""
+
+#: tmainform.aboutaction.caption
+msgid "AboutAction"
+msgstr ""
+
+#: tmainform.actioncheckupdates.caption
+msgctxt "tmainform.actioncheckupdates.caption"
+msgid "Check for updates"
+msgstr ""
+
+#: tmainform.activelayercolor.caption
+msgid "Active layer color"
+msgstr ""
+
+#: tmainform.activelayercolor.hint
+msgctxt "tmainform.activelayercolor.hint"
+msgid "Change the color of the currently active layer."
+msgstr ""
+
+#: tmainform.addcylinder.caption
+msgid "Add cylinder..."
+msgstr ""
+
+#: tmainform.addflowline.caption
+msgctxt "tmainform.addflowline.caption"
+msgid "Add flow line"
+msgstr ""
+
+#: tmainform.addgridpanel.caption
+msgid "Add grid panel"
+msgstr ""
+
+#: tmainform.addpoint.caption
+msgctxt "tmainform.addpoint.caption"
+msgid "Add"
+msgstr ""
+
+#: tmainform.addpoint.hint
+msgid "Add a new controlpoint to the model."
+msgstr ""
+
+#: tmainform.addpointtogroup.caption
+msgid "Add Point To Group"
+msgstr ""
+
+#: tmainform.bothsides.caption
+msgid "Show both sides"
+msgstr ""
+
+#: tmainform.bothsides.hint
+msgid "Show both sides of the model"
+msgstr ""
+
+#: tmainform.calculations1.caption
+msgid "Calculations"
+msgstr ""
+
+#: tmainform.cascadewindow.caption
+msgid "Cascade"
+msgstr ""
+
+#: tmainform.cbprecision.hint
+msgctxt "tmainform.cbprecision.hint"
+msgid "Precision"
+msgstr ""
+
+#: tmainform.cbprecision.text
+msgctxt "tmainform.cbprecision.text"
+msgid "Medium"
+msgstr ""
+
+#: tmainform.checkmodel.caption
+msgid "Check model"
+msgstr ""
+
+#: tmainform.checkmodel.hint
+msgid "Check the model for errors and inconsitencies."
+msgstr ""
+
+#: tmainform.clearundo.caption
+msgctxt "tmainform.clearundo.caption"
+msgid "Clear"
+msgstr ""
+
+#: tmainform.colorbutton1.hint
+msgctxt "tmainform.colorbutton1.hint"
+msgid "Change the color of the currently active layer."
+msgstr ""
+
+#: tmainform.crosscurves.caption
+msgctxt "tmainform.crosscurves.caption"
+msgid "Cross curves"
+msgstr ""
+
+#: tmainform.curve1.caption
+msgctxt "tmainform.curve1.caption"
+msgid "Curve"
+msgstr ""
+
+#: tmainform.decreasecurvaturescale.caption
+msgid "Decr. curvature scale"
+msgstr ""
+
+#: tmainform.decreasecurvaturescale.hint
+msgid "Decrease the scale of the curvature plots"
+msgstr ""
+
+#: tmainform.delete.caption
+msgctxt "tmainform.delete.caption"
+msgid "Delete"
+msgstr ""
+
+#: tmainform.delete.hint
+msgid "Delete all selected items."
+msgstr ""
+
+#: tmainform.deleteemptylayers.caption
+msgid "Delete empty"
+msgstr ""
+
+#: tmainform.deleteemptylayers.hint
+msgid "Delete empty layers from the model."
+msgstr ""
+
+#: tmainform.deletemarkers.caption
+msgid "Delete all markers"
+msgstr ""
+
+#: tmainform.deletemarkers.hint
+msgid "Delete all markers from the model."
+msgstr ""
+
+#: tmainform.deselectall.caption
+msgctxt "tmainform.deselectall.caption"
+msgid "Deselect all"
+msgstr ""
+
+#: tmainform.deselectall.hint
+msgctxt "tmainform.deselectall.hint"
+msgid "Deselect all"
+msgstr ""
+
+#: tmainform.designhydrostatics.caption
+msgid "Design hydrostatics"
+msgstr ""
+
+#: tmainform.designhydrostatics.hint
+msgid "Calculate hydrostatics for the design condition."
+msgstr ""
+
+#: tmainform.developlayers.caption
+msgid "Develop plates"
+msgstr ""
+
+#: tmainform.edge1.caption
+msgid "Edge"
+msgstr ""
+
+#: tmainform.edgecollapse.caption
+msgctxt "tmainform.edgecollapse.caption"
+msgid "Collapse"
+msgstr ""
+
+#: tmainform.edgecollapse.hint
+msgid "Remove an edge by merging the two connected faces into one new face."
+msgstr ""
+
+#: tmainform.edgecrease.caption
+msgctxt "tmainform.edgecrease.caption"
+msgid "Crease"
+msgstr ""
+
+#: tmainform.edgecrease.hint
+msgid "Switch selected edges between normal or crease edges (knuckle lines)."
+msgstr ""
+
+#: tmainform.edgeextrude.caption
+msgid "Extrude..."
+msgstr ""
+
+#: tmainform.edgeextrude.hint
+msgid "Create new controlfaces by extruding selected boundary edges."
+msgstr ""
+
+#: tmainform.edgesplit.caption
+msgid "Split"
+msgstr ""
+
+#: tmainform.edgesplit.hint
+msgid "Create new controlpoints by splitting an controledge into two."
+msgstr ""
+
+#: tmainform.edit1.caption
+msgid "Edit"
+msgstr ""
+
+#: tmainform.editprojectsettings.caption
+msgid "Project settings"
+msgstr ""
+
+#: tmainform.exitprogram.caption
+msgid "Exit"
+msgstr ""
+
+#: tmainform.exitprogram.hint
+msgid "Quit FreeShip"
+msgstr ""
+
+#: tmainform.export1.caption
+msgctxt "tmainform.export1.caption"
+msgid "Export"
+msgstr ""
+
+#: tmainform.exportaddmass.caption
+msgid "Export and calculation Add_Mass"
+msgstr ""
+
+#: tmainform.exportarchimedes.caption
+msgid "Archimedes..."
+msgstr ""
+
+#: tmainform.exportarchimedes.hint
+msgid "Export stations to Arcimedes"
+msgstr ""
+
+#: tmainform.exportcoordinates.caption
+msgid "Coordinates..."
+msgstr ""
+
+#: tmainform.exportdxf2dpolylines.caption
+msgid "DXF 2D Polylines..."
+msgstr ""
+
+#: tmainform.exportdxf2dpolylines.hint
+msgid "Export all lines as 2D polylines."
+msgstr ""
+
+#: tmainform.exportdxf3dpolylines.caption
+msgid "DXF 3D Polylines..."
+msgstr ""
+
+#: tmainform.exportdxf3dpolylines.hint
+msgid "Export all lines as 3D polylines."
+msgstr ""
+
+#: tmainform.exportdxffaces.caption
+msgid "DXF 3D mesh..."
+msgstr ""
+
+#: tmainform.exportdxffaces.hint
+msgid "Export all faces to a 3D DXF file."
+msgstr ""
+
+#: tmainform.exportfef.caption
+msgctxt "tmainform.exportfef.caption"
+msgid "FEF file..."
+msgstr ""
+
+#: tmainform.exportfef.hint
+msgid "Export to a FEF (Freeship Exchange Format) hull."
+msgstr ""
+
+#: tmainform.exportghs.caption
+msgid "GHS..."
+msgstr ""
+
+#: tmainform.exportiges.caption
+msgid "IGES"
+msgstr ""
+
+#: tmainform.exportmichlet.caption
+msgid "Michlet..."
+msgstr ""
+
+#: tmainform.exportobj.caption
+msgid "Wavefront file (Obj)..."
+msgstr ""
+
+#: tmainform.exportoffsets.caption
+msgid "Offsets..."
+msgstr ""
+
+#: tmainform.exportpam.caption
+msgid "Add_Mass *.PAM"
+msgstr ""
+
+#: tmainform.exportpart.caption
+msgctxt "tmainform.exportpart.caption"
+msgid "Part..."
+msgstr ""
+
+#: tmainform.exportstl.caption
+msgid "STL..."
+msgstr ""
+
+#: tmainform.face1.caption
+msgid "Face"
+msgstr ""
+
+#: tmainform.file1.caption
+msgid "File"
+msgstr ""
+
+#: tmainform.filesave.caption
+msgctxt "tmainform.filesave.caption"
+msgid "Save"
+msgstr ""
+
+#: tmainform.filesave.hint
+msgid "Save file without prompting for the filename."
+msgstr ""
+
+#: tmainform.filesaveas.caption
+msgid "Save as..."
+msgstr ""
+
+#: tmainform.filesaveas.hint
+msgid "Prompt for filename and save file."
+msgstr ""
+
+#: tmainform.help1.caption
+msgctxt "tmainform.help1.caption"
+msgid "Help"
+msgstr ""
+
+#: tmainform.helpabout.caption
+msgid "About"
+msgstr ""
+
+#: tmainform.helpaction.caption
+msgid "HelpAction"
+msgstr ""
+
+#: tmainform.helpcontents.caption
+msgid "Contents"
+msgstr ""
+
+#: tmainform.hydrodynmaneuv_.caption
+msgid "HydrodynManeuv"
+msgstr ""
+
+#: tmainform.hydrodyntask.caption
+msgid "Hydrodynamics characteristics"
+msgstr ""
+
+#: tmainform.hydrodyntask1_.caption
+msgid "HydrodynAero"
+msgstr ""
+
+#: tmainform.hydrodyntask2_.caption
+msgid "HydrodynPosition"
+msgstr ""
+
+#: tmainform.hydrodyntask3_.caption
+msgid "HydrodynRotation"
+msgstr ""
+
+#: tmainform.hydrodyntask4_.caption
+msgid "Import results of Add_Mass"
+msgstr ""
+
+#: tmainform.hydrostaticsdialog.caption
+msgid "Hydrostatics..."
+msgstr ""
+
+#: tmainform.hydrostaticsdialog.hint
+msgid "Calculate hydrostatics for a range of inputdata."
+msgstr ""
+
+#: tmainform.import1.caption
+msgctxt "tmainform.import1.caption"
+msgid "Import"
+msgstr ""
+
+#: tmainform.importbodyplan.caption
+msgid "Bodyplan..."
+msgstr ""
+
+#: tmainform.importbodyplan.hint
+msgid "Import a bodyplan and fit a surface."
+msgstr ""
+
+#: tmainform.importcarene.caption
+msgid "Carene XYZ file..."
+msgstr ""
+
+#: tmainform.importchines.caption
+msgid "Chines..."
+msgstr ""
+
+#: tmainform.importfef.caption
+msgctxt "tmainform.importfef.caption"
+msgid "FEF file..."
+msgstr ""
+
+#: tmainform.importfef.hint
+msgid "Import a FEF (Freeship Exchange Format) hull."
+msgstr ""
+
+#: tmainform.importhullfile.caption
+msgid "Carlson .hul file..."
+msgstr ""
+
+#: tmainform.importmarkers.caption
+msgctxt "tmainform.importmarkers.caption"
+msgid "Import"
+msgstr ""
+
+#: tmainform.importmichletwaves.caption
+msgid "Michlet waves..."
+msgstr ""
+
+#: tmainform.importpart.caption
+msgctxt "tmainform.importpart.caption"
+msgid "Part..."
+msgstr ""
+
+#: tmainform.importpolycad.caption
+msgid "PolyCad"
+msgstr ""
+
+#: tmainform.importsurface.caption
+msgid "Surface..."
+msgstr ""
+
+#: tmainform.importvrml.caption
+msgid "VRML..."
+msgstr ""
+
+#: tmainform.importvrml.hint
+msgid "Import a VRML 1.0 file."
+msgstr ""
+
+#: tmainform.increasecurvaturescale.caption
+msgid "Incr. curvature scale"
+msgstr ""
+
+#: tmainform.increasecurvaturescale.hint
+msgid "Increase the scale of the curvature plots"
+msgstr ""
+
+#: tmainform.insertplane.caption
+msgid "Insert plane..."
+msgstr ""
+
+#: tmainform.insertplane.hint
+msgid "Insert multiple new points on a 3D oriented plane."
+msgstr ""
+
+#: tmainform.intersectiondialog.caption
+msgid "Intersections..."
+msgstr ""
+
+#: tmainform.intersectiondialog.hint
+msgid "Show the window to add stations, buttocks, waterlines and diagonals."
+msgstr ""
+
+#: tmainform.invertface.caption
+msgid "Invert"
+msgstr ""
+
+#: tmainform.invertface.hint
+msgid "Flip the normal direction of the selected controlfaces."
+msgstr ""
+
+#: tmainform.keelrudderwizard.caption
+msgctxt "tmainform.keelrudderwizard.caption"
+msgid "Keel and rudder wizard"
+msgstr ""
+
+#: tmainform.keelrudderwizard.hint
+msgid "Create a default rudder or keel."
+msgstr ""
+
+#: tmainform.labeldistance.caption
+msgid "distance : "
+msgstr ""
+
+#: tmainform.labelnumbers.caption
+msgid "LabelNumbers"
+msgstr ""
+
+#: tmainform.labelprogress.caption
+msgid "LabelProgress"
+msgstr ""
+
+#: tmainform.labelundomemory.caption
+msgid "Undo memory : 0 kb."
+msgstr ""
+
+#: tmainform.layer1.caption
+msgctxt "tmainform.layer1.caption"
+msgid "Layer"
+msgstr ""
+
+#: tmainform.layerautogroup.caption
+msgid "Auto group"
+msgstr ""
+
+#: tmainform.layerautogroup.hint
+msgid "Automatic grouping of connected controlfaces into a new layer."
+msgstr ""
+
+#: tmainform.layerbox.text
+msgid "LayerBox"
+msgstr ""
+
+#: tmainform.layerdialog.caption
+msgid "Dialog"
+msgstr ""
+
+#: tmainform.layerdialog.hint
+msgid "Show the window with layer properties."
+msgstr ""
+
+#: tmainform.layerintersection.caption
+msgid "Intersect layers..."
+msgstr ""
+
+#: tmainform.layerintersection.hint
+msgid "Find the intersection of two layers."
+msgstr ""
+
+#: tmainform.layervisibilitydialog.caption
+msgid "Layer visibility dialog"
+msgstr ""
+
+#: tmainform.layervisibilitydialog.hint
+msgid "Show Layer visibility dialog"
+msgstr ""
+
+#: tmainform.loadfile.caption
+msgid "Open..."
+msgstr ""
+
+#: tmainform.loadfile.hint
+msgid "Open a new file."
+msgstr ""
+
+#: tmainform.markers2.caption
+msgctxt "tmainform.markers2.caption"
+msgid "Markers"
+msgstr ""
+
+#: tmainform.menuitem1.caption
+msgctxt "tmainform.menuitem1.caption"
+msgid "Add flow line"
+msgstr ""
+
+#: tmainform.menuitempointalignpermanently.caption
+msgid "Align Permanently"
+msgstr ""
+
+#: tmainform.mirrorface.caption
+msgid "Mirror..."
+msgstr ""
+
+#: tmainform.movemodel.caption
+msgid "Move..."
+msgstr ""
+
+#: tmainform.movemodel.hint
+msgid "Move the entire model."
+msgstr ""
+
+#: tmainform.newcurve.caption
+msgctxt "tmainform.newcurve.caption"
+msgid "New"
+msgstr ""
+
+#: tmainform.newcurve.hint
+msgid "Add a new curve to selected edges."
+msgstr ""
+
+#: tmainform.newedge.caption
+msgid "Insert"
+msgstr ""
+
+#: tmainform.newedge.hint
+msgid "Split a face by inserting a new edge between to selected points."
+msgstr ""
+
+#: tmainform.newface.caption
+msgctxt "tmainform.newface.caption"
+msgid "New"
+msgstr ""
+
+#: tmainform.newface.hint
+msgid "Create a new controlface from selected controlpoints."
+msgstr ""
+
+#: tmainform.newlayer.caption
+msgctxt "tmainform.newlayer.caption"
+msgid "New"
+msgstr ""
+
+#: tmainform.newlayer.hint
+msgid "Add a new empty layer to the model."
+msgstr ""
+
+#: tmainform.newmodel.caption
+msgid "New..."
+msgstr ""
+
+#: tmainform.newmodel.hint
+msgid "Start a new model."
+msgstr ""
+
+#: tmainform.newwindow.caption
+msgid "New window"
+msgstr ""
+
+#: tmainform.ools1.caption
+msgid "Tools"
+msgstr ""
+
+#: tmainform.point1.caption
+msgid "Point"
+msgstr ""
+
+#: tmainform.pointalighnpermanently.caption
+msgid "Point Alighn Permanently"
+msgstr ""
+
+#: tmainform.pointalign.caption
+msgid "Align"
+msgstr ""
+
+#: tmainform.pointalign.hint
+msgid ""
+"Project selected points on a straight line through the first and last "
+"selected point."
+msgstr ""
+
+#: tmainform.pointanchor.caption
+msgctxt "tmainform.pointanchor.caption"
+msgid "Anchor"
+msgstr ""
+
+#: tmainform.pointcollapse.caption
+msgctxt "tmainform.pointcollapse.caption"
+msgid "Collapse"
+msgstr ""
+
+#: tmainform.pointcollapse.hint
+msgid "Merge two selected edges by removing their common controlpoint."
+msgstr ""
+
+#: tmainform.pointextrude.caption
+msgid "Extrude points"
+msgstr ""
+
+#: tmainform.pointscoincide.caption
+msgid "Coincide points"
+msgstr ""
+
+#: tmainform.pointscoincide.hint
+msgid "Coincide points to the first selected one"
+msgstr ""
+
+#: tmainform.pointslock.caption
+msgid "Lock points"
+msgstr ""
+
+#: tmainform.pointslock.hint
+msgid "Lock all selected controlpoints."
+msgstr ""
+
+#: tmainform.pointsunlock.caption
+msgid "Unlock points"
+msgstr ""
+
+#: tmainform.pointsunlock.hint
+msgid "Unlock all selected controlpoints."
+msgstr ""
+
+#: tmainform.pointsunlockall.caption
+msgid "Unlock all points"
+msgstr ""
+
+#: tmainform.pointsunlockall.hint
+msgid "Unlock all locked controlpoints."
+msgstr ""
+
+#: tmainform.preferences.caption
+msgid "Preferences"
+msgstr ""
+
+#: tmainform.project1.caption
+msgctxt "tmainform.project1.caption"
+msgid "Project"
+msgstr ""
+
+#: tmainform.propellerrvrs.caption
+msgid "Hydrodynamics ship tasks"
+msgstr ""
+
+#: tmainform.propellertask1.caption
+msgid "Design of propeller"
+msgstr ""
+
+#: tmainform.proptask1_.caption
+msgid "PropTask1"
+msgstr ""
+
+#: tmainform.proptask2_.caption
+msgid "PropTask2"
+msgstr ""
+
+#: tmainform.proptask3_.caption
+msgid "PropTask3"
+msgstr ""
+
+#: tmainform.proptask4_.caption
+msgid "PropTask4"
+msgstr ""
+
+#: tmainform.proptask5_.caption
+msgid "PropTask5"
+msgstr ""
+
+#: tmainform.proptaskrvrs_.caption
+msgid "PropTaskRvrs"
+msgstr ""
+
+#: tmainform.ransform1.caption
+msgctxt "tmainform.ransform1.caption"
+msgid "Transform"
+msgstr ""
+
+#: tmainform.recentfiles.caption
+msgid "Recent files"
+msgstr ""
+
+#: tmainform.redo.caption
+msgctxt "tmainform.redo.caption"
+msgid "Redo"
+msgstr ""
+
+#: tmainform.redo.hint
+msgid "Undo the previous modification."
+msgstr ""
+
+#: tmainform.removenegative.caption
+msgid "Remove negative"
+msgstr ""
+
+#: tmainform.removenegative.hint
+msgid "Removes all faces on the starbaordside of the hull."
+msgstr ""
+
+#: tmainform.removeunusedpoints.caption
+msgid "Remove unused points"
+msgstr ""
+
+#: tmainform.resistance1.caption
+msgctxt "tmainform.resistance1.caption"
+msgid "Resistance"
+msgstr "Resistência ao avanço"
+
+#: tmainform.resistancedelft.caption
+msgid "Delft yacht series"
+msgstr ""
+
+#: tmainform.resistancefungleib.caption
+msgid "Method Fung-Leibman"
+msgstr ""
+
+#: tmainform.resistancehollen.caption
+msgid "Method Hollenbach"
+msgstr ""
+
+#: tmainform.resistanceholtr.caption
+msgid "Method Holtrop"
+msgstr ""
+
+#: tmainform.resistancekaper.caption
+msgid "KAPER"
+msgstr ""
+
+#: tmainform.resistancemh.caption
+msgid "Multihull ships methods"
+msgstr ""
+
+#: tmainform.resistanceoortmer.caption
+msgid "Method van Oortmerssen"
+msgstr ""
+
+#: tmainform.resistanceost.caption
+msgid "OST 5.0181-75 sea vessel series"
+msgstr ""
+
+#: tmainform.resistanceplaning.caption
+msgid "Planing resistance method"
+msgstr ""
+
+#: tmainform.resistancerbhs.caption
+msgid "High Speed Round Bilge ships methods"
+msgstr ""
+
+#: tmainform.rotatemodel.caption
+msgid "Rotate..."
+msgstr ""
+
+#: tmainform.rotatemodel.hint
+msgid "Rotate selected items."
+msgstr ""
+
+#: tmainform.rotatemodelm.caption
+msgid "Heeling and/or trimming..."
+msgstr ""
+
+#: tmainform.rotatemodelm.hint
+msgid "Rotate all model items."
+msgstr ""
+
+#: tmainform.scalemodel.caption
+msgid "Scale..."
+msgstr ""
+
+#: tmainform.scalemodel.hint
+msgid "Scale selected items."
+msgstr ""
+
+#: tmainform.selectall.caption
+msgid "Select all"
+msgstr ""
+
+#: tmainform.selectallcontrolpoints.caption
+msgctxt "tmainform.selectallcontrolpoints.caption"
+msgid "Select All Control Points"
+msgstr ""
+
+#: tmainform.selectallcontrolpoints.hint
+msgctxt "tmainform.selectallcontrolpoints.hint"
+msgid "Select All Control Points"
+msgstr ""
+
+#: tmainform.selection1.caption
+msgid "Selection"
+msgstr ""
+
+#: tmainform.selectiondialog.caption
+msgid "Selection Dialog"
+msgstr ""
+
+#: tmainform.selectleakpoints.caption
+msgid "SelectLeakPoints"
+msgstr ""
+
+#: tmainform.showbuttocks.caption
+msgctxt "tmainform.showbuttocks.caption"
+msgid "Buttocks"
+msgstr "Linhas do alto"
+
+#: tmainform.showbuttocks.hint
+msgid "Toggle buttocks visibility on or off."
+msgstr ""
+
+#: tmainform.showcontrolcurves.caption
+msgctxt "tmainform.showcontrolcurves.caption"
+msgid "Control curves"
+msgstr ""
+
+#: tmainform.showcontrolcurves.hint
+msgid "Show control curves."
+msgstr ""
+
+#: tmainform.showcontrolnet.caption
+msgid "Control net"
+msgstr ""
+
+#: tmainform.showcontrolnet.hint
+msgid "Show control net."
+msgstr ""
+
+#: tmainform.showcurvature.caption
+msgctxt "tmainform.showcurvature.caption"
+msgid "Curvature"
+msgstr ""
+
+#: tmainform.showcurvature.hint
+msgid "Show curvature plot of intersectionlines."
+msgstr ""
+
+#: tmainform.showdiagonals.caption
+msgctxt "tmainform.showdiagonals.caption"
+msgid "Diagonals"
+msgstr ""
+
+#: tmainform.showdiagonals.hint
+msgid "Toggle diagonals visibility on or off."
+msgstr ""
+
+#: tmainform.showflowlines.caption
+msgid "Flowlines"
+msgstr ""
+
+#: tmainform.showflowlines.hint
+msgid "Show flowlines around the hull."
+msgstr ""
+
+#: tmainform.showfreeobjects.caption
+msgid "Show free objects"
+msgstr ""
+
+#: tmainform.showfreeobjects.hint
+msgid "Show objects not associated with any layer"
+msgstr ""
+
+#: tmainform.showgrid.caption
+msgid "Grid"
+msgstr ""
+
+#: tmainform.showgrid.hint
+msgid "Show grid of intersections in plan, profile and bodyplan view."
+msgstr ""
+
+#: tmainform.showhydrostatics.caption
+msgid "Hydrostatic features"
+msgstr ""
+
+#: tmainform.showhydrostatics.hint
+msgid "Show certain hydrostatic key properties in the model."
+msgstr ""
+
+#: tmainform.showinterioredges.caption
+msgctxt "tmainform.showinterioredges.caption"
+msgid "Interior edges"
+msgstr ""
+
+#: tmainform.showinterioredges.hint
+msgctxt "tmainform.showinterioredges.hint"
+msgid "Show interior edges."
+msgstr ""
+
+#: tmainform.showlinesplan.caption
+msgid "Linesplan"
+msgstr ""
+
+#: tmainform.showmarkers.caption
+msgctxt "tmainform.showmarkers.caption"
+msgid "Markers"
+msgstr ""
+
+#: tmainform.showmarkers.hint
+msgid "Show markers."
+msgstr ""
+
+#: tmainform.shownormals.caption
+msgid "Normals"
+msgstr ""
+
+#: tmainform.shownormals.hint
+msgid "Show normals of selected controlfaces."
+msgstr ""
+
+#: tmainform.showstations.caption
+msgctxt "tmainform.showstations.caption"
+msgid "Stations"
+msgstr "Balizas"
+
+#: tmainform.showstations.hint
+msgid "Toggle stations visibility on or off."
+msgstr ""
+
+#: tmainform.showundohistory.caption
+msgid "Browse..."
+msgstr ""
+
+#: tmainform.showwaterlines.caption
+msgctxt "tmainform.showwaterlines.caption"
+msgid "Waterlines"
+msgstr ""
+
+#: tmainform.showwaterlines.hint
+msgid "Toggle waterlines visibility on or off."
+msgstr ""
+
+#: tmainform.spineditfontsize.hint
+msgctxt "tmainform.spineditfontsize.hint"
+msgid "Font Size"
+msgstr ""
+
+#: tmainform.splitsection50pct.caption
+msgid "Split Section middle location"
+msgstr ""
+
+#: tmainform.splitsection50pct.hint
+msgid "Set Split Section location to middle of length"
+msgstr ""
+
+#: tmainform.splitsectiondialog.caption
+msgctxt "tmainform.splitsectiondialog.caption"
+msgid "Split Section location"
+msgstr ""
+
+#: tmainform.splitsectiondialog.hint
+msgid "Set Split Section location in Body Plan"
+msgstr ""
+
+#: tmainform.tilewindow.caption
+msgid "Tile"
+msgstr ""
+
+#: tmainform.toolbarcurves.caption
+msgctxt "tmainform.toolbarcurves.caption"
+msgid "ToolBarFile"
+msgstr ""
+
+#: tmainform.toolbaredges.caption
+msgctxt "tmainform.toolbaredges.caption"
+msgid "ToolBarFile"
+msgstr ""
+
+#: tmainform.toolbaredit.caption
+msgctxt "tmainform.toolbaredit.caption"
+msgid "ToolBarFile"
+msgstr ""
+
+#: tmainform.toolbarfaces.caption
+msgctxt "tmainform.toolbarfaces.caption"
+msgid "ToolBarFile"
+msgstr ""
+
+#: tmainform.toolbarfile.caption
+msgctxt "tmainform.toolbarfile.caption"
+msgid "ToolBarFile"
+msgstr ""
+
+#: tmainform.toolbarlayers.caption
+msgctxt "tmainform.toolbarlayers.caption"
+msgid "ToolBarFile"
+msgstr ""
+
+#: tmainform.toolbarpoints.caption
+msgid "ToolBarPoints"
+msgstr ""
+
+#: tmainform.toolbarvisibility.caption
+msgctxt "tmainform.toolbarvisibility.caption"
+msgid "ToolBarFile"
+msgstr ""
+
+#: tmainform.toolbuttonselect.hint
+msgid "Deselect All"
+msgstr ""
+
+#: tmainform.transformlackenby.caption
+msgid "Lackenby..."
+msgstr ""
+
+#: tmainform.undo.caption
+msgctxt "tmainform.undo.caption"
+msgid "Undo"
+msgstr ""
+
+#: tmainform.undo.hint
+msgid "Undo the last modification."
+msgstr ""
+
+#: tmainform.undohistory1.caption
+msgid "Undo history"
+msgstr ""
+
+#: tmainform.visibility1.caption
+msgid "Visibility"
+msgstr ""
+
+#: tmainform.window1.caption
+msgid "Window"
+msgstr ""
+
+#: tsaveimagedialog.bitbtn1.caption
+msgctxt "tsaveimagedialog.bitbtn1.caption"
+msgid "OK"
+msgstr ""
+
+#: tsaveimagedialog.bitbtn2.caption
+msgctxt "tsaveimagedialog.bitbtn2.caption"
+msgid "Cancel"
+msgstr ""
+
+#: tsaveimagedialog.caption
+msgid "Save image."
+msgstr ""
+
+#: tsaveimagedialog.edit3.text
+msgctxt "tsaveimagedialog.edit3.text"
+msgid "Edit3"
+msgstr ""
+
+#: tsaveimagedialog.label1.caption
+msgid "Width"
+msgstr ""
+
+#: tsaveimagedialog.label2.caption
+msgid "Height"
+msgstr ""
+
+#: tsaveimagedialog.label3.caption
+msgctxt "tsaveimagedialog.label3.caption"
+msgid "[pixels]"
+msgstr ""
+
+#: tsaveimagedialog.label4.caption
+msgid "Estimated size"
+msgstr ""
+
+#: tsaveimagedialog.label5.caption
+msgid "KB"
+msgstr ""
+
+#: tsaveimagedialog.label6.caption
+msgctxt "tsaveimagedialog.label6.caption"
+msgid "[pixels]"
+msgstr ""
+
+#: tsaveimagedialog.label7.caption
+msgctxt "tsaveimagedialog.label7.caption"
+msgid "Filename"
+msgstr ""
+
+#: ttiledialog.actionopen.caption
+msgid "ActionOpen"
+msgstr ""
+
+#: ttiledialog.actionopenanother.caption
+msgid "ActionOpenAnother"
+msgstr ""
+
+#: ttiledialog.actionremove.caption
+msgid "ActionRemove"
+msgstr ""
+
+#: ttiledialog.bbclose.caption
+msgctxt "ttiledialog.bbclose.caption"
+msgid "Close"
+msgstr ""
+
+#: ttiledialog.buttonopenfile.caption
+msgid "Open Another"
+msgstr ""
+
+#: ttiledialog.menuitemopen.caption
+msgctxt "ttiledialog.menuitemopen.caption"
+msgid "Open"
+msgstr ""
+
+#: ttiledialog.menuitemremove.caption
+msgid "Remove"
+msgstr ""
+
+#: ttiledialog.menuitemremove.hint
+msgid "Remove project from this \"Recent projects\" list"
+msgstr ""
+
+#: ttiledialog.panel1.caption
+msgctxt "ttiledialog.panel1.caption"
+msgid "Panel1"
+msgstr ""
+
+#: ttiledialog.panel2.caption
+msgctxt "ttiledialog.panel2.caption"
+msgid "Panel2"
+msgstr ""
+
+#: ttiledialog.toppanel.caption
+msgid "Recent projects"
+msgstr ""


### PR DESCRIPTION
Initial translation file for Brazilian Portuguese (pt-BR) with naval engineering terminology adapted. I will keep pushing updates to this branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add initial Brazilian Portuguese (pt-BR) translation with naval engineering terms adapted for local usage. Introduces `locale/FreeShip.pt_BR.po` to enable pt-BR localization.

<sup>Written for commit a86c8508f99336d70e9a40fd03e93f7077ecec89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/markmal/freeship-plus-in-lazarus/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

